### PR TITLE
Rename thread init

### DIFF
--- a/include/dice/events/thread.h
+++ b/include/dice/events/thread.h
@@ -5,7 +5,7 @@
 #ifndef DICE_THREAD_H
 #define DICE_THREAD_H
 
-#define EVENT_THREAD_INIT 1
-#define EVENT_THREAD_FINI 2
+#define EVENT_THREAD_START 1
+#define EVENT_THREAD_EXIT  2
 
 #endif /* DICE_THREAD_H */

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # Copyright (C) Huawei Technologies Co., Ltd. 2025. All rights reserved.
 # SPDX-License-Identifier: MIT
-#
+
 set -e
 
 OPTION_CLEAN=no

--- a/scripts/list_events.sh
+++ b/scripts/list_events.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+#
+#
+DIR=.
+rg --no-heading                 \
+   "define EVENT_.*[0-9]+" $DIR \
+    | grep -v scripts           \
+    | tr ":" " " | tr -s " "    \
+    | cut -d" " -f1,3,4         \
+    | mlr --ifs=" " --opprint   \
+      label file,event,constant \
+      then cut -o -f event,constant,file \
+      then sort -n -f constant \
+    | less

--- a/scripts/list_events.sh
+++ b/scripts/list_events.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
-#
-#
+# Copyright (C) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+set -e
+
+# Depends on ripgrep (rg) and miller (mlr)
+
 DIR=.
 rg --no-heading                 \
    "define EVENT_.*[0-9]+" $DIR \

--- a/scripts/update-bench-index.sh
+++ b/scripts/update-bench-index.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # Copyright (C) Huawei Technologies Co., Ltd. 2025. All rights reserved.
 # SPDX-License-Identifier: MIT
-#
+
 set -e
 
 # assume starting from project root and dice.wiki is cloned there

--- a/src/mod/pthread_create.c
+++ b/src/mod/pthread_create.c
@@ -22,7 +22,7 @@ DICE_NORET
 INTERPOSE(void, pthread_exit, void *ptr)
 {
     struct pthread_exit_event ev = {.pc = INTERPOSE_PC, .ptr = ptr};
-    PS_PUBLISH(INTERCEPT_EVENT, EVENT_THREAD_FINI, &ev, 0);
+    PS_PUBLISH(INTERCEPT_EVENT, EVENT_THREAD_EXIT, &ev, 0);
     REAL(pthread_exit, ptr);
     exit(1); // unreachable
 }
@@ -35,9 +35,9 @@ _trampoline(void *targ)
     void *(*run)(void *) = t->run;
     mempool_free(t);
 
-    PS_PUBLISH(INTERCEPT_EVENT, EVENT_THREAD_INIT, 0, 0);
+    PS_PUBLISH(INTERCEPT_EVENT, EVENT_THREAD_START, 0, 0);
     void *ret = run(arg);
-    PS_PUBLISH(INTERCEPT_EVENT, EVENT_THREAD_FINI, 0, 0);
+    PS_PUBLISH(INTERCEPT_EVENT, EVENT_THREAD_EXIT, 0, 0);
     return ret;
 }
 

--- a/src/mod/sequencer.c
+++ b/src/mod/sequencer.c
@@ -10,10 +10,10 @@
 
 PS_SUBSCRIBE(CAPTURE_EVENT, ANY_TYPE, {
     switch (type) {
-        case EVENT_THREAD_FINI:
+        case EVENT_THREAD_EXIT:
             switcher_wake(ANY_THREAD, 0);
             break;
-        case EVENT_THREAD_INIT:
+        case EVENT_THREAD_START:
             /* threads call this only ONCE (except the main thread). */
             switcher_yield(self_id(md), true);
             break;

--- a/test/interpose/interpose_test.c.in
+++ b/test/interpose/interpose_test.c.in
@@ -13,19 +13,19 @@
 #define $_include(...)
 #define MM_RETURN_FOO int
 #define MM_PARAMS_FOO
-#define EVENT_UPCASE 1
-#define PARAM        int x
-#define AA           1
-#define E_FOO(...)   1
-#define E_FOO(...)   1
+#define MAKE_UPCASE 1
+#define PARAM       int x
+#define AA          1
+#define E_FOO(...)  1
+#define E_FOO(...)  1
 int FOO(int);
 #define INCL       <stdio.h>
 #define $_unmute() // end of fake definitions
 $_dl(); // ---------------------------------------------------------------------
 $_dl(); // mapping and tmplr configuration
 $_dl(); // ---------------------------------------------------------------------
-$_dl(); // EVENT_UPCASE can be used to force FOO to be upcased in EVENT_FOO
-$_map(EVENT_UPCASE, $_upcase(EVENT_FOO));
+$_dl(); // MAKE_UPCASE can be used to force FOO to be upcased in EVENT_FOO
+$_map(MAKE_UPCASE, $_upcase(EVENT_FOO));
 $_dl(); // $_returns X $.? deletes line if X == "void", outputs nothing
 $_dl(); // $_returns X $.!? deletes line if X == "void", otherwise outputs X
 $_map($_returns void $, $_dl);
@@ -115,7 +115,7 @@ $_end();
     ensure(memcmp(&ev->field, &(E)->field, sizeof(__typeof((E)->field))) == 0);
 
 $_begin(FOO = [[foo]]);
-PS_SUBSCRIBE(INTERCEPT_BEFORE, EVENT_UPCASE, {
+PS_SUBSCRIBE(INTERCEPT_BEFORE, MAKE_UPCASE, {
     if (!enabled())
         return PS_STOP_CHAIN;
     struct FOO_event *ev = EVENT_PAYLOAD(ev);
@@ -124,7 +124,7 @@ PS_SUBSCRIBE(INTERCEPT_BEFORE, EVENT_UPCASE, {
     $__end();
 })
 
-PS_SUBSCRIBE(INTERCEPT_AFTER, EVENT_UPCASE, {
+PS_SUBSCRIBE(INTERCEPT_AFTER, MAKE_UPCASE, {
     if (!enabled())
         return PS_STOP_CHAIN;
     struct FOO_event *ev = EVENT_PAYLOAD(ev);

--- a/test/pthread_create_detach.c
+++ b/test/pthread_create_detach.c
@@ -19,8 +19,8 @@ int run_called;
 vatomic32_t done;
 vatomic32_t start;
 
-PS_SUBSCRIBE(INTERCEPT_EVENT, EVENT_THREAD_INIT, { init_called++; })
-PS_SUBSCRIBE(INTERCEPT_EVENT, EVENT_THREAD_FINI, {
+PS_SUBSCRIBE(INTERCEPT_EVENT, EVENT_THREAD_START, { init_called++; })
+PS_SUBSCRIBE(INTERCEPT_EVENT, EVENT_THREAD_EXIT, {
     fini_called++;
     vatomic_inc(&done);
 })

--- a/test/pthread_create_exit.c
+++ b/test/pthread_create_exit.c
@@ -15,8 +15,8 @@ int init_called;
 int fini_called;
 int run_called;
 
-PS_SUBSCRIBE(INTERCEPT_EVENT, EVENT_THREAD_INIT, { init_called++; })
-PS_SUBSCRIBE(INTERCEPT_EVENT, EVENT_THREAD_FINI, { fini_called++; })
+PS_SUBSCRIBE(INTERCEPT_EVENT, EVENT_THREAD_START, { init_called++; })
+PS_SUBSCRIBE(INTERCEPT_EVENT, EVENT_THREAD_EXIT, { fini_called++; })
 
 void *
 run()

--- a/test/pthread_create_join.c
+++ b/test/pthread_create_join.c
@@ -15,8 +15,8 @@ int init_called;
 int fini_called;
 int run_called;
 
-PS_SUBSCRIBE(INTERCEPT_EVENT, EVENT_THREAD_INIT, { init_called++; })
-PS_SUBSCRIBE(INTERCEPT_EVENT, EVENT_THREAD_FINI, { fini_called++; })
+PS_SUBSCRIBE(INTERCEPT_EVENT, EVENT_THREAD_START, { init_called++; })
+PS_SUBSCRIBE(INTERCEPT_EVENT, EVENT_THREAD_EXIT, { fini_called++; })
 
 void *
 run()


### PR DESCRIPTION
Renames thread events to match the start and exit of the user thread routine. Adds a script to list all event constants and the file where they are defined.