### PR TITLE
self: Fix guards of THREAD_JOIN

### DIFF
--- a/include/dice/self.h
+++ b/include/dice/self.h
@@ -20,6 +20,8 @@
 /* Get unique thread id */
 thread_id self_id(metadata_t *self);
 
+bool self_retired(metadata_t *self);
+
 /* Get or allocate a memory area in TLS.
  *
  * `global` must be a unique pointer, typically a global variable of the desired


### PR DESCRIPTION
Previously, self module was calling directly the macro self_guard. And that introduced an error in the counting of the guard for THREAD_JOIN. So this PR adds asserts to ensure the correct counting (see _self_handle_*) and makes all publications to go via these functions instead of self_guard directly.