### PR TITLE
dispatch: Split dispatch as separate module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,11 +12,14 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 add_compile_options(-Wall -Wextra -Werror)
 
 # LTO setup
-if(CMAKE_SYSTEM_NAME MATCHES "NetBSD" AND "${CMAKE_C_COMPILER_ID}" MATCHES
-                                          "Clang")
-  add_compile_options(-flto -ffat-lto-objects)
-else()
-  set(CMAKE_INTERPROCEDURAL_OPTIMIZATION on)
+option(DICE_LTO "Build Dice with LTO" on)
+if(${DICE_LTO})
+  if(CMAKE_SYSTEM_NAME MATCHES "NetBSD" AND "${CMAKE_C_COMPILER_ID}" MATCHES
+                                            "Clang")
+    add_compile_options(-flto -ffat-lto-objects)
+  else()
+    set(CMAKE_INTERPROCEDURAL_OPTIMIZATION on)
+  endif()
 endif()
 
 # POSIX extensions

--- a/include/dice/dispatch.h
+++ b/include/dice/dispatch.h
@@ -18,7 +18,7 @@
     }
 
 DICE_HIDE bool
-V_JOIN(V_JOIN(ps_dispatch, DICE_MODULE_PRIO), on_)(void)
+V_JOIN(V_JOIN(ps_dispatch_slot, DICE_MODULE_PRIO), on_)(void)
 {
     return true;
 }

--- a/src/dice/CMakeLists.txt
+++ b/src/dice/CMakeLists.txt
@@ -34,11 +34,11 @@ add_custom_command(
   DEPENDS dispatch.c.in
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 add_custom_target(expand-dispatch DEPENDS tmplr dispatch.c)
-set(DISPATCH_SRCS dispatch.c)
 
 # CHAIN_CONTROL has only events 98..99
 set(EEE_0 98 99)
 
+set(DISPATCH_SRCS loader.c)
 foreach(CHAIN ${CHAINS})
   list(APPEND DISPATCH_SRCS dispatch_${CHAIN}.c)
   set(eee "${EEE}")
@@ -58,16 +58,21 @@ foreach(CHAIN ${CHAINS})
   add_dependencies(expand-dispatch expand-dispatch_${CHAIN})
 endforeach()
 
-set(SRCS)
+set(_DSRCS)
 foreach(SRC ${DISPATCH_SRCS})
-  set(SRCS ${SRCS} ${CMAKE_CURRENT_SOURCE_DIR}/${SRC})
+  set(_DSRCS ${_DSRCS} ${CMAKE_CURRENT_SOURCE_DIR}/${SRC})
 endforeach()
+set(DISPATCH_SRCS ${_DSRCS})
 
 # dice libraries
-set(SRCS mempool.c rbtree.c loader.c pubsub.c ${SRCS})
+set(SRCS mempool.c rbtree.c pubsub.c ${CMAKE_CURRENT_SOURCE_DIR}/dispatch.c)
 add_library(dice.o OBJECT ${SRCS})
 target_link_libraries(dice.o PUBLIC dice.h)
 target_compile_options(dice.o PRIVATE -fPIC)
+
+add_library(dice-dispatch.o OBJECT ${DISPATCH_SRCS})
+target_link_libraries(dice-dispatch.o PUBLIC dice.h)
+target_compile_options(dice-dispatch.o PRIVATE -fPIC)
 
 add_library(dice-box.o OBJECT box.c)
 target_link_libraries(dice-box.o PUBLIC dice.h)

--- a/src/dice/CMakeLists.txt
+++ b/src/dice/CMakeLists.txt
@@ -71,11 +71,14 @@ target_link_libraries(dice.o PUBLIC dice.h)
 target_compile_options(dice.o PRIVATE -fPIC)
 
 add_library(dice-dispatch.o OBJECT ${DISPATCH_SRCS})
-target_link_libraries(dice-dispatch.o PUBLIC dice.h)
 target_compile_options(dice-dispatch.o PRIVATE -fPIC)
+target_link_libraries(dice-dispatch.o PRIVATE dice.h)
 
+# linking with dice-box.o will bring dice-dispatch.o as public dependency
 add_library(dice-box.o OBJECT box.c)
-target_link_libraries(dice-box.o PUBLIC dice.h)
+target_compile_options(dice-box.o PRIVATE -fPIC)
+target_link_libraries(dice-box.o PUBLIC dice-dispatch.o)
+target_link_libraries(dice-box.o PRIVATE dice.h)
 
 add_library(dice SHARED ${SRCS})
 target_link_libraries(dice PUBLIC dice.h pthread)

--- a/src/dice/dispatch.c
+++ b/src/dice/dispatch.c
@@ -15,6 +15,12 @@ ps_dispatch_0_(const chain_id chain, const type_id type, void *event,
     (void)md;
     return PS_HANDLER_OFF;
 }
+
+DICE_WEAK DICE_HIDE bool
+ps_dispatch_chain_0_on_(void)
+{
+    return false;
+}
 DICE_WEAK DICE_HIDE enum ps_err
 ps_dispatch_1_(const chain_id chain, const type_id type, void *event,
                  metadata_t *md)
@@ -24,6 +30,12 @@ ps_dispatch_1_(const chain_id chain, const type_id type, void *event,
     (void)event;
     (void)md;
     return PS_HANDLER_OFF;
+}
+
+DICE_WEAK DICE_HIDE bool
+ps_dispatch_chain_1_on_(void)
+{
+    return false;
 }
 DICE_WEAK DICE_HIDE enum ps_err
 ps_dispatch_2_(const chain_id chain, const type_id type, void *event,
@@ -35,6 +47,12 @@ ps_dispatch_2_(const chain_id chain, const type_id type, void *event,
     (void)md;
     return PS_HANDLER_OFF;
 }
+
+DICE_WEAK DICE_HIDE bool
+ps_dispatch_chain_2_on_(void)
+{
+    return false;
+}
 DICE_WEAK DICE_HIDE enum ps_err
 ps_dispatch_3_(const chain_id chain, const type_id type, void *event,
                  metadata_t *md)
@@ -44,6 +62,12 @@ ps_dispatch_3_(const chain_id chain, const type_id type, void *event,
     (void)event;
     (void)md;
     return PS_HANDLER_OFF;
+}
+
+DICE_WEAK DICE_HIDE bool
+ps_dispatch_chain_3_on_(void)
+{
+    return false;
 }
 DICE_WEAK DICE_HIDE enum ps_err
 ps_dispatch_4_(const chain_id chain, const type_id type, void *event,
@@ -55,6 +79,12 @@ ps_dispatch_4_(const chain_id chain, const type_id type, void *event,
     (void)md;
     return PS_HANDLER_OFF;
 }
+
+DICE_WEAK DICE_HIDE bool
+ps_dispatch_chain_4_on_(void)
+{
+    return false;
+}
 DICE_WEAK DICE_HIDE enum ps_err
 ps_dispatch_5_(const chain_id chain, const type_id type, void *event,
                  metadata_t *md)
@@ -65,6 +95,12 @@ ps_dispatch_5_(const chain_id chain, const type_id type, void *event,
     (void)md;
     return PS_HANDLER_OFF;
 }
+
+DICE_WEAK DICE_HIDE bool
+ps_dispatch_chain_5_on_(void)
+{
+    return false;
+}
 DICE_WEAK DICE_HIDE enum ps_err
 ps_dispatch_6_(const chain_id chain, const type_id type, void *event,
                  metadata_t *md)
@@ -74,6 +110,35 @@ ps_dispatch_6_(const chain_id chain, const type_id type, void *event,
     (void)event;
     (void)md;
     return PS_HANDLER_OFF;
+}
+
+DICE_WEAK DICE_HIDE bool
+ps_dispatch_chain_6_on_(void)
+{
+    return false;
+}
+
+DICE_HIDE bool
+ps_dispatch_chain_on_(const chain_id chain)
+{
+    switch (chain) {
+        case 0:
+            return ps_dispatch_chain_0_on_();
+        case 1:
+            return ps_dispatch_chain_1_on_();
+        case 2:
+            return ps_dispatch_chain_2_on_();
+        case 3:
+            return ps_dispatch_chain_3_on_();
+        case 4:
+            return ps_dispatch_chain_4_on_();
+        case 5:
+            return ps_dispatch_chain_5_on_();
+        case 6:
+            return ps_dispatch_chain_6_on_();
+        default:
+            return false;
+    }
 }
 
 /* main dispatcher */
@@ -101,124 +166,122 @@ ps_dispatch_(const chain_id chain, const type_id type, void *event,
     }
 }
 
+DICE_WEAK DICE_HIDE bool
+ps_dispatch_slot_0_on_(void)
+{
+    return false;
+}
+DICE_WEAK DICE_HIDE bool
+ps_dispatch_slot_1_on_(void)
+{
+    return false;
+}
+DICE_WEAK DICE_HIDE bool
+ps_dispatch_slot_2_on_(void)
+{
+    return false;
+}
+DICE_WEAK DICE_HIDE bool
+ps_dispatch_slot_3_on_(void)
+{
+    return false;
+}
+DICE_WEAK DICE_HIDE bool
+ps_dispatch_slot_4_on_(void)
+{
+    return false;
+}
+DICE_WEAK DICE_HIDE bool
+ps_dispatch_slot_5_on_(void)
+{
+    return false;
+}
+DICE_WEAK DICE_HIDE bool
+ps_dispatch_slot_6_on_(void)
+{
+    return false;
+}
+DICE_WEAK DICE_HIDE bool
+ps_dispatch_slot_7_on_(void)
+{
+    return false;
+}
+DICE_WEAK DICE_HIDE bool
+ps_dispatch_slot_8_on_(void)
+{
+    return false;
+}
+DICE_WEAK DICE_HIDE bool
+ps_dispatch_slot_9_on_(void)
+{
+    return false;
+}
+DICE_WEAK DICE_HIDE bool
+ps_dispatch_slot_10_on_(void)
+{
+    return false;
+}
+DICE_WEAK DICE_HIDE bool
+ps_dispatch_slot_11_on_(void)
+{
+    return false;
+}
+DICE_WEAK DICE_HIDE bool
+ps_dispatch_slot_12_on_(void)
+{
+    return false;
+}
+DICE_WEAK DICE_HIDE bool
+ps_dispatch_slot_13_on_(void)
+{
+    return false;
+}
+DICE_WEAK DICE_HIDE bool
+ps_dispatch_slot_14_on_(void)
+{
+    return false;
+}
+DICE_WEAK DICE_HIDE bool
+ps_dispatch_slot_15_on_(void)
+{
+    return false;
+}
 
-DICE_WEAK DICE_HIDE bool
-ps_dispatch_0_on_(void)
-{
-    return false;
-}
-DICE_WEAK DICE_HIDE bool
-ps_dispatch_1_on_(void)
-{
-    return false;
-}
-DICE_WEAK DICE_HIDE bool
-ps_dispatch_2_on_(void)
-{
-    return false;
-}
-DICE_WEAK DICE_HIDE bool
-ps_dispatch_3_on_(void)
-{
-    return false;
-}
-DICE_WEAK DICE_HIDE bool
-ps_dispatch_4_on_(void)
-{
-    return false;
-}
-DICE_WEAK DICE_HIDE bool
-ps_dispatch_5_on_(void)
-{
-    return false;
-}
-DICE_WEAK DICE_HIDE bool
-ps_dispatch_6_on_(void)
-{
-    return false;
-}
-DICE_WEAK DICE_HIDE bool
-ps_dispatch_7_on_(void)
-{
-    return false;
-}
-DICE_WEAK DICE_HIDE bool
-ps_dispatch_8_on_(void)
-{
-    return false;
-}
-DICE_WEAK DICE_HIDE bool
-ps_dispatch_9_on_(void)
-{
-    return false;
-}
-DICE_WEAK DICE_HIDE bool
-ps_dispatch_10_on_(void)
-{
-    return false;
-}
-DICE_WEAK DICE_HIDE bool
-ps_dispatch_11_on_(void)
-{
-    return false;
-}
-DICE_WEAK DICE_HIDE bool
-ps_dispatch_12_on_(void)
-{
-    return false;
-}
-DICE_WEAK DICE_HIDE bool
-ps_dispatch_13_on_(void)
-{
-    return false;
-}
-DICE_WEAK DICE_HIDE bool
-ps_dispatch_14_on_(void)
-{
-    return false;
-}
-DICE_WEAK DICE_HIDE bool
-ps_dispatch_15_on_(void)
-{
-    return false;
-}
-
-DICE_HIDE
-int
+DICE_HIDE int
 ps_dispatch_max(void)
 {
     int max = -1;
-    if (ps_dispatch_0_on_())
+    if (ps_dispatch_slot_0_on_())
         max = max < 0 ? 0 : max;
-    if (ps_dispatch_1_on_())
+    if (ps_dispatch_slot_1_on_())
         max = max < 1 ? 1 : max;
-    if (ps_dispatch_2_on_())
+    if (ps_dispatch_slot_2_on_())
         max = max < 2 ? 2 : max;
-    if (ps_dispatch_3_on_())
+    if (ps_dispatch_slot_3_on_())
         max = max < 3 ? 3 : max;
-    if (ps_dispatch_4_on_())
+    if (ps_dispatch_slot_4_on_())
         max = max < 4 ? 4 : max;
-    if (ps_dispatch_5_on_())
+    if (ps_dispatch_slot_5_on_())
         max = max < 5 ? 5 : max;
-    if (ps_dispatch_6_on_())
+    if (ps_dispatch_slot_6_on_())
         max = max < 6 ? 6 : max;
-    if (ps_dispatch_7_on_())
+    if (ps_dispatch_slot_7_on_())
         max = max < 7 ? 7 : max;
-    if (ps_dispatch_8_on_())
+    if (ps_dispatch_slot_8_on_())
         max = max < 8 ? 8 : max;
-    if (ps_dispatch_9_on_())
+    if (ps_dispatch_slot_9_on_())
         max = max < 9 ? 9 : max;
-    if (ps_dispatch_10_on_())
+    if (ps_dispatch_slot_10_on_())
         max = max < 10 ? 10 : max;
-    if (ps_dispatch_11_on_())
+    if (ps_dispatch_slot_11_on_())
         max = max < 11 ? 11 : max;
-    if (ps_dispatch_12_on_())
+    if (ps_dispatch_slot_12_on_())
         max = max < 12 ? 12 : max;
-    if (ps_dispatch_13_on_())
+    if (ps_dispatch_slot_13_on_())
         max = max < 13 ? 13 : max;
-    if (ps_dispatch_14_on_())
+    if (ps_dispatch_slot_14_on_())
         max = max < 14 ? 14 : max;
-    if (ps_dispatch_15_on_())
+    if (ps_dispatch_slot_15_on_())
         max = max < 15 ? 15 : max;
 
     return max;

--- a/src/dice/dispatch.c.in
+++ b/src/dice/dispatch.c.in
@@ -28,7 +28,26 @@ ps_dispatch_CCC_(const chain_id chain, const type_id type, void *event,
     (void)md;
     return PS_HANDLER_OFF;
 }
+
+DICE_WEAK DICE_HIDE bool
+ps_dispatch_chain_CCC_on_(void)
+{
+    return false;
+}
 _tmpl_end();
+
+DICE_HIDE bool
+ps_dispatch_chain_on_(const chain_id chain)
+{
+    switch (chain) {
+        _tmpl_begin(CCC = CHAINS);
+        case CCC:
+            return ps_dispatch_chain_CCC_on_();
+            _tmpl_end();
+        default:
+            return false;
+    }
+}
 
 /* main dispatcher */
 DICE_HIDE enum ps_err
@@ -45,22 +64,20 @@ ps_dispatch_(const chain_id chain, const type_id type, void *event,
     }
 }
 
-
 _tmpl_begin(SSS = SLOTS);
 DICE_WEAK DICE_HIDE bool
-ps_dispatch_SSS_on_(void)
+ps_dispatch_slot_SSS_on_(void)
 {
     return false;
 }
 _tmpl_end();
 
-DICE_HIDE
-int
+DICE_HIDE int
 ps_dispatch_max(void)
 {
     int max = -1;
     _tmpl_begin(SSS = SLOTS);
-    if (ps_dispatch_SSS_on_())
+    if (ps_dispatch_slot_SSS_on_())
         max = max < SSS ? SSS : max;
     _tmpl_end();
 

--- a/src/dice/dispatch_0.c
+++ b/src/dice/dispatch_0.c
@@ -802,3 +802,8 @@ ps_dispatch_0_(const chain_id chain, const type_id type, void *event,
             return ps_dispatch_0_99_(chain, type, event, md);
     }
 }
+DICE_HIDE bool
+ps_dispatch_chain_0_on_(void)
+{
+    return true;
+}

--- a/src/dice/dispatch_1.c
+++ b/src/dice/dispatch_1.c
@@ -40240,3 +40240,8 @@ ps_dispatch_1_(const chain_id chain, const type_id type, void *event,
             return ps_dispatch_1_128_(chain, type, event, md);
     }
 }
+DICE_HIDE bool
+ps_dispatch_chain_1_on_(void)
+{
+    return true;
+}

--- a/src/dice/dispatch_2.c
+++ b/src/dice/dispatch_2.c
@@ -40240,3 +40240,8 @@ ps_dispatch_2_(const chain_id chain, const type_id type, void *event,
             return ps_dispatch_2_128_(chain, type, event, md);
     }
 }
+DICE_HIDE bool
+ps_dispatch_chain_2_on_(void)
+{
+    return true;
+}

--- a/src/dice/dispatch_3.c
+++ b/src/dice/dispatch_3.c
@@ -40240,3 +40240,8 @@ ps_dispatch_3_(const chain_id chain, const type_id type, void *event,
             return ps_dispatch_3_128_(chain, type, event, md);
     }
 }
+DICE_HIDE bool
+ps_dispatch_chain_3_on_(void)
+{
+    return true;
+}

--- a/src/dice/dispatch_4.c
+++ b/src/dice/dispatch_4.c
@@ -40240,3 +40240,8 @@ ps_dispatch_4_(const chain_id chain, const type_id type, void *event,
             return ps_dispatch_4_128_(chain, type, event, md);
     }
 }
+DICE_HIDE bool
+ps_dispatch_chain_4_on_(void)
+{
+    return true;
+}

--- a/src/dice/dispatch_5.c
+++ b/src/dice/dispatch_5.c
@@ -40240,3 +40240,8 @@ ps_dispatch_5_(const chain_id chain, const type_id type, void *event,
             return ps_dispatch_5_128_(chain, type, event, md);
     }
 }
+DICE_HIDE bool
+ps_dispatch_chain_5_on_(void)
+{
+    return true;
+}

--- a/src/dice/dispatch_6.c
+++ b/src/dice/dispatch_6.c
@@ -40240,3 +40240,8 @@ ps_dispatch_6_(const chain_id chain, const type_id type, void *event,
             return ps_dispatch_6_128_(chain, type, event, md);
     }
 }
+DICE_HIDE bool
+ps_dispatch_chain_6_on_(void)
+{
+    return true;
+}

--- a/src/dice/dispatch_chain.c.in
+++ b/src/dice/dispatch_chain.c.in
@@ -77,4 +77,9 @@ ps_dispatch_CCC_(const chain_id chain, const type_id type, void *event,
             _tmpl2_end();
     }
 }
+DICE_HIDE bool
+ps_dispatch_chain_CCC_on_(void)
+{
+    return true;
+}
 _tmpl_end();

--- a/src/dice/pubsub.c
+++ b/src/dice/pubsub.c
@@ -13,6 +13,7 @@
 #define MAX_SUBSCRIPTIONS 255
 
 int ps_dispatch_max(void);
+bool ps_dispatch_chain_on_(chain_id);
 
 struct sub {
     chain_id chain;
@@ -133,8 +134,9 @@ ps_subscribe(chain_id chain, type_id type, ps_callback_f cb, int prio)
 {
     ps_init_(); // ensure initialized
 
-    if (prio <= ps_dispatch_max()) {
-        log_debug("Ignoring %u %u %d", chain, type, prio);
+    log_debug("Subscribe %u_%u_%d", chain, type, prio);
+    if (ps_dispatch_chain_on_(chain) && prio <= ps_dispatch_max()) {
+        log_debug("Ignore subscription %u_%u_%d", chain, type, prio);
         return PS_OK;
     }
     if (chain == CHAIN_CONTROL)
@@ -202,6 +204,7 @@ ps_publish(const chain_id chain, const type_id type, void *event,
     if (unlikely(!ps_initd_()))
         return PS_DROP_EVENT;
 
+    log_debug("Publish %u_%u", chain, type);
     enum ps_err err = ps_dispatch_(chain, type, event, md);
 
     if (likely(err == PS_STOP_CHAIN))

--- a/test/order/CMakeLists.txt
+++ b/test/order/CMakeLists.txt
@@ -73,8 +73,9 @@ add_test(NAME preload-21-test
                  ./order_test 2 202)
 
 add_library(subscriber21f SHARED)
-target_link_libraries(subscriber21f PRIVATE publisher.o subscriber2.o
-                                            subscriber1.o dice.o)
+target_link_libraries(
+  subscriber21f PRIVATE publisher.o subscriber2.o subscriber1.o dice.o
+                        dice-dispatch.o)
 
 add_test(NAME preload-21f-test
          COMMAND env LD_LIBRARY_PATH=. LD_PRELOAD=libsubscriber21f.so


### PR DESCRIPTION

`ps_dispatch` guarantees that all modules (builtins or plugins) are initialized and can handle events as soon as the first `ps_publish` is called. That is restricted to the *dispatch-chains*, which are the first 16 chains.

The dispatch chains are usable immediately after initialization even if 
1. the event happens before the `main()` function is called
2. or the handlers is in plugins.

Unfortunately, the linker has a tremendous work to optimize and link all the dispatch functions and that greatly increases the build time of the project. In many cases, however, it might be OK dropping all events before the main function has been called, so that maybe we can make the dispatch functions optional.

This PR makes `ps_dispatch` be an extra module of Dice. `libdice.so` has no dispatchers, and when building a Dice-based library, one has to link with `dice-dispatch.o` to add the dispatch functionality.