### PR TITLE
test: Use ensure instead of assert in tests

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,9 +1,16 @@
 # Copyright (C) Huawei Technologies Co., Ltd. 2025. All rights reserved.
 # SPDX-License-Identifier: 0BSD
 
-add_subdirectory(checkers)
+# test-specific includes such as dice/ensure.h
 include_directories(include)
+
+# to ensure tsan and other compiler passes work, use builtin atomics
 add_compile_options(-DVATOMIC_BUILTINS)
+
+# checkers used for other tests
+add_subdirectory(checkers)
+
+# test configuration
 set(TSAN_mp on)
 set(TSAN_simple-tsan on)
 set(DICE_simple on)

--- a/test/checkers/malloc_free_check.c
+++ b/test/checkers/malloc_free_check.c
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: 0BSD
  */
 
-#include <assert.h>
+#include <dice/ensure.h>
 #include <stdio.h>
 
 #include <dice/chains/capture.h>
@@ -49,11 +49,11 @@ DICE_MODULE_FINI({
     // Ensure the self module has been loaded. The self module interrupts
     // the INTERCEPT chains, handles TLS and redirects the events to
     // equivalent CAPTURE chains.
-    assert(intercepted[EVENT_MALLOC] == 0);
-    assert(intercepted[EVENT_FREE] == 0);
+    ensure(intercepted[EVENT_MALLOC] == 0);
+    ensure(intercepted[EVENT_FREE] == 0);
 
     // Ensure that at least one malloc was captured
-    assert(captured[EVENT_MALLOC] > 0);
+    ensure(captured[EVENT_MALLOC] > 0);
 
 // We would like to ensure that all captured mallocs had a corresponding
 // free. But that is quite hard. Free is also often called with 0 pointer.
@@ -61,9 +61,9 @@ DICE_MODULE_FINI({
 // than mallocs (or the same number). On other systems, the best claim is that
 // frees are not 0.
 #if defined(__linux__)
-    assert(captured[EVENT_MALLOC] <= captured[EVENT_FREE]);
+    ensure(captured[EVENT_MALLOC] <= captured[EVENT_FREE]);
 #else
-    assert(captured[EVENT_MALLOC] > 0);
-    assert(captured[EVENT_FREE] > 0);
+    ensure(captured[EVENT_MALLOC] > 0);
+    ensure(captured[EVENT_FREE] > 0);
 #endif
 })

--- a/test/intercept_event.c
+++ b/test/intercept_event.c
@@ -2,7 +2,7 @@
  * Copyright (C) Huawei Technologies Co., Ltd. 2025. All rights reserved.
  * SPDX-License-Identifier: 0BSD
  */
-#include <assert.h>
+#include <dice/ensure.h>
 #include <pthread.h>
 #include <unistd.h>
 
@@ -35,6 +35,6 @@ main(void)
     struct ma_awrite_event ev = {0};
     ev.val.u64                = EXPECTED;
     PS_PUBLISH(INTERCEPT_EVENT, EVENT_MA_AWRITE, &ev, 0);
-    assert(received);
+    ensure(received);
     return 0;
 }

--- a/test/interpose/cxa_test.c
+++ b/test/interpose/cxa_test.c
@@ -8,16 +8,10 @@
 
 #define DICE_TEST_INTERPOSE
 #include <dice/chains/intercept.h>
+#include <dice/ensure.h>
 #include <dice/interpose.h>
 #include <dice/pubsub.h>
 #include <dice/events/cxa.h>
-
-#define ensure(COND)                                                           \
-    {                                                                          \
-        if (!(COND)) {                                                         \
-            log_fatal("error: %s", #COND);                                     \
-        }                                                                      \
-    }
 
 static void *symbol;
 /* we need to declare this as noinline, otherwise the optimization of the

--- a/test/interpose/interpose_test.c.in
+++ b/test/interpose/interpose_test.c.in
@@ -39,22 +39,12 @@ $_dl(); // ---------------------------------------------------------------------
 
 #define DICE_TEST_INTERPOSE
 #include <dice/chains/intercept.h>
+#include <dice/ensure.h>
 #include <dice/interpose.h>
 #include <dice/pubsub.h>
 $_begin(INCL = [[stdio.h]]);
 #include INCL
 $_end();
-
-#define ensure(COND)                                                           \
-    {                                                                          \
-        if (!(COND)) {                                                         \
-            log_fatal("error: %s", #COND);                                     \
-        }                                                                      \
-    }
-$_mute();
-#undef ensure
-#define ensure(...)
-$_unmute();
 
 static void *symbol;
 /* we need to declare this as noinline, otherwise the optimization of the

--- a/test/interpose/mman_test.c
+++ b/test/interpose/mman_test.c
@@ -8,16 +8,10 @@
 
 #define DICE_TEST_INTERPOSE
 #include <dice/chains/intercept.h>
+#include <dice/ensure.h>
 #include <dice/interpose.h>
 #include <dice/pubsub.h>
 #include <dice/events/mman.h>
-
-#define ensure(COND)                                                           \
-    {                                                                          \
-        if (!(COND)) {                                                         \
-            log_fatal("error: %s", #COND);                                     \
-        }                                                                      \
-    }
 
 static void *symbol;
 /* we need to declare this as noinline, otherwise the optimization of the

--- a/test/interpose/pthread_cond_test.c
+++ b/test/interpose/pthread_cond_test.c
@@ -8,16 +8,10 @@
 
 #define DICE_TEST_INTERPOSE
 #include <dice/chains/intercept.h>
+#include <dice/ensure.h>
 #include <dice/interpose.h>
 #include <dice/pubsub.h>
 #include <dice/events/pthread.h>
-
-#define ensure(COND)                                                           \
-    {                                                                          \
-        if (!(COND)) {                                                         \
-            log_fatal("error: %s", #COND);                                     \
-        }                                                                      \
-    }
 
 static void *symbol;
 /* we need to declare this as noinline, otherwise the optimization of the

--- a/test/interpose/pthread_create_test.c
+++ b/test/interpose/pthread_create_test.c
@@ -8,16 +8,10 @@
 
 #define DICE_TEST_INTERPOSE
 #include <dice/chains/intercept.h>
+#include <dice/ensure.h>
 #include <dice/interpose.h>
 #include <dice/pubsub.h>
 #include <dice/events/pthread.h>
-
-#define ensure(COND)                                                           \
-    {                                                                          \
-        if (!(COND)) {                                                         \
-            log_fatal("error: %s", #COND);                                     \
-        }                                                                      \
-    }
 
 static void *symbol;
 /* we need to declare this as noinline, otherwise the optimization of the

--- a/test/interpose/pthread_mutex_test.c
+++ b/test/interpose/pthread_mutex_test.c
@@ -8,16 +8,10 @@
 
 #define DICE_TEST_INTERPOSE
 #include <dice/chains/intercept.h>
+#include <dice/ensure.h>
 #include <dice/interpose.h>
 #include <dice/pubsub.h>
 #include <dice/events/pthread.h>
-
-#define ensure(COND)                                                           \
-    {                                                                          \
-        if (!(COND)) {                                                         \
-            log_fatal("error: %s", #COND);                                     \
-        }                                                                      \
-    }
 
 static void *symbol;
 /* we need to declare this as noinline, otherwise the optimization of the

--- a/test/interpose/pthread_rwlock_test.c
+++ b/test/interpose/pthread_rwlock_test.c
@@ -8,16 +8,10 @@
 
 #define DICE_TEST_INTERPOSE
 #include <dice/chains/intercept.h>
+#include <dice/ensure.h>
 #include <dice/interpose.h>
 #include <dice/pubsub.h>
 #include <dice/events/pthread.h>
-
-#define ensure(COND)                                                           \
-    {                                                                          \
-        if (!(COND)) {                                                         \
-            log_fatal("error: %s", #COND);                                     \
-        }                                                                      \
-    }
 
 static void *symbol;
 /* we need to declare this as noinline, otherwise the optimization of the

--- a/test/interpose/sem_test.c
+++ b/test/interpose/sem_test.c
@@ -8,16 +8,10 @@
 
 #define DICE_TEST_INTERPOSE
 #include <dice/chains/intercept.h>
+#include <dice/ensure.h>
 #include <dice/interpose.h>
 #include <dice/pubsub.h>
 #include <dice/events/semaphore.h>
-
-#define ensure(COND)                                                           \
-    {                                                                          \
-        if (!(COND)) {                                                         \
-            log_fatal("error: %s", #COND);                                     \
-        }                                                                      \
-    }
 
 static void *symbol;
 /* we need to declare this as noinline, otherwise the optimization of the

--- a/test/malloc_free_test.c
+++ b/test/malloc_free_test.c
@@ -2,7 +2,7 @@
  * Copyright (C) Huawei Technologies Co., Ltd. 2025. All rights reserved.
  * SPDX-License-Identifier: 0BSD
  */
-#include <assert.h>
+#include <dice/ensure.h>
 #include <pthread.h>
 #include <stdlib.h>
 

--- a/test/order/defs.h
+++ b/test/order/defs.h
@@ -5,6 +5,7 @@
 #ifndef ORDER_DEFS_H
 #define ORDER_DEFS_H
 
+#include <dice/ensure.h>
 #include <dice/log.h>
 #include <dice/pubsub.h>
 #define CHAIN 1
@@ -16,12 +17,5 @@ struct event {
 };
 
 void publish(struct event *ev);
-
-#define ensure(COND)                                                           \
-    {                                                                          \
-        if (!(COND)) {                                                         \
-            log_fatal("error: %s", #COND);                                     \
-        }                                                                      \
-    }
 
 #endif /* ORDER_DEFS_H */

--- a/test/pthread_create_detach.c
+++ b/test/pthread_create_detach.c
@@ -2,7 +2,7 @@
  * Copyright (C) Huawei Technologies Co., Ltd. 2025. All rights reserved.
  * SPDX-License-Identifier: 0BSD
  */
-#include <assert.h>
+#include <dice/ensure.h>
 #include <pthread.h>
 
 #include <dice/chains/intercept.h>
@@ -42,9 +42,9 @@ main()
     vatomic_inc(&start);
     vatomic_await_neq(&done, 0);
 
-    assert(run_called == 1);
-    assert(init_called == 1);
-    assert(fini_called == 1);
+    ensure(run_called == 1);
+    ensure(init_called == 1);
+    ensure(fini_called == 1);
 
     return 0;
 }

--- a/test/pthread_create_exit.c
+++ b/test/pthread_create_exit.c
@@ -2,7 +2,7 @@
  * Copyright (C) Huawei Technologies Co., Ltd. 2025. All rights reserved.
  * SPDX-License-Identifier: 0BSD
  */
-#include <assert.h>
+#include <dice/ensure.h>
 #include <pthread.h>
 
 #include <dice/chains/intercept.h>
@@ -35,9 +35,9 @@ main()
     pthread_create(&t, 0, run, 0);
     pthread_join(t, 0);
 
-    assert(vatomic_read(&run_called) == 1);
-    assert(vatomic_read(&init_called) == 1);
-    assert(vatomic_read(&fini_called) == 1);
+    ensure(vatomic_read(&run_called) == 1);
+    ensure(vatomic_read(&init_called) == 1);
+    ensure(vatomic_read(&fini_called) == 1);
 
     return 0;
 }

--- a/test/pthread_create_join.c
+++ b/test/pthread_create_join.c
@@ -2,7 +2,7 @@
  * Copyright (C) Huawei Technologies Co., Ltd. 2025. All rights reserved.
  * SPDX-License-Identifier: 0BSD
  */
-#include <assert.h>
+#include <dice/ensure.h>
 #include <pthread.h>
 
 #include <dice/chains/intercept.h>
@@ -32,9 +32,9 @@ main()
     pthread_create(&t, 0, run, 0);
     pthread_join(t, 0);
 
-    assert(run_called == 1);
-    assert(init_called == 1);
-    assert(fini_called == 1);
+    ensure(run_called == 1);
+    ensure(init_called == 1);
+    ensure(fini_called == 1);
 
     return 0;
 }

--- a/test/self/self_unique_test.c
+++ b/test/self/self_unique_test.c
@@ -2,11 +2,11 @@
  * Copyright (C) Huawei Technologies Co., Ltd. 2025. All rights reserved.
  * SPDX-License-Identifier: 0BSD
  */
-#include <assert.h>
 #include <pthread.h>
 
 #include <dice/chains/capture.h>
 #include <dice/chains/intercept.h>
+#include <dice/ensure.h>
 #include <dice/module.h>
 #include <dice/self.h>
 
@@ -15,10 +15,10 @@ vatomic32_t exists[NTHREADS];
 
 PS_SUBSCRIBE(CAPTURE_EVENT, EVENT_SELF_INIT, {
     thread_id id = self_id(md);
-    assert(id > 0);
+    ensure(id > 0);
     // ids start with 1
     uint32_t count = vatomic_get_inc(exists + id - 1);
-    assert(count == 0);
+    ensure(count == 0);
 })
 
 void *
@@ -49,7 +49,7 @@ main(void)
     // here we check that every thread (including the main thread) has received
     // SELF_INIT once and only once.
     for (int i = 0; i < NTHREADS; i++)
-        assert(vatomic_read(exists + i) == 1);
+        ensure(vatomic_read(exists + i) == 1);
 
     return 0;
 }

--- a/test/simple-tsan.c
+++ b/test/simple-tsan.c
@@ -2,7 +2,7 @@
  * Copyright (C) Huawei Technologies Co., Ltd. 2025. All rights reserved.
  * SPDX-License-Identifier: 0BSD
  */
-#include <assert.h>
+#include <dice/ensure.h>
 #include <pthread.h>
 #include <stdio.h>
 
@@ -26,7 +26,7 @@ run1(void *_)
     (void)_;
     printf("here\n");
     if (vatomic32_read(&ready) == 1)
-        assert(data == 1);
+        ensure(data == 1);
     printf("there\n");
     return 0;
 }

--- a/test/simple.c
+++ b/test/simple.c
@@ -2,7 +2,7 @@
  * Copyright (C) Huawei Technologies Co., Ltd. 2025. All rights reserved.
  * SPDX-License-Identifier: 0BSD
  */
-#include <assert.h>
+#include <dice/ensure.h>
 #include <pthread.h>
 #include <stdio.h>
 
@@ -31,7 +31,7 @@ run1(void *_)
 
     PS_PUBLISH(INTERCEPT_EVENT, EVENT_MA_AREAD, 0, 0);
     if (vatomic32_read(&ready) == 1)
-        assert(data == 1);
+        ensure(data == 1);
     printf("there\n");
     return 0;
 }

--- a/test/switcher/abort_test.c
+++ b/test/switcher/abort_test.c
@@ -2,7 +2,7 @@
  * Copyright (C) Huawei Technologies Co., Ltd. 2025. All rights reserved.
  * SPDX-License-Identifier: 0BSD
  */
-#include <assert.h>
+#include <dice/ensure.h>
 #include <pthread.h>
 #include <stdbool.h>
 #include <stdio.h>

--- a/test/switcher/anythread_test.c
+++ b/test/switcher/anythread_test.c
@@ -2,7 +2,7 @@
  * Copyright (C) Huawei Technologies Co., Ltd. 2025. All rights reserved.
  * SPDX-License-Identifier: 0BSD
  */
-#include <assert.h>
+#include <dice/ensure.h>
 #include <pthread.h>
 #include <stdbool.h>
 

--- a/test/switcher/slack_test.c
+++ b/test/switcher/slack_test.c
@@ -2,7 +2,7 @@
  * Copyright (C) Huawei Technologies Co., Ltd. 2025. All rights reserved.
  * SPDX-License-Identifier: 0BSD
  */
-#include <assert.h>
+#include <dice/ensure.h>
 #include <pthread.h>
 #include <stdbool.h>
 #include <stdio.h>

--- a/test/switcher/yield_continue_test.c
+++ b/test/switcher/yield_continue_test.c
@@ -2,7 +2,7 @@
  * Copyright (C) Huawei Technologies Co., Ltd. 2025. All rights reserved.
  * SPDX-License-Identifier: 0BSD
  */
-#include <assert.h>
+#include <dice/ensure.h>
 #include <pthread.h>
 #include <stdbool.h>
 #include <stdio.h>
@@ -26,7 +26,7 @@ r1()
     switcher_wake(2, 0);
     yd = switcher_yield(tid, false);
     printf("condition true %d\n", yd == SWITCHER_CONTINUE);
-    assert(yd == SWITCHER_CONTINUE);
+    ensure(yd == SWITCHER_CONTINUE);
     return 0;
 }
 

--- a/test/tsan/tsan_test.c
+++ b/test/tsan/tsan_test.c
@@ -2,12 +2,12 @@
  * Copyright (C) Huawei Technologies Co., Ltd. 2025. All rights reserved.
  * SPDX-License-Identifier: 0BSD
  */
-#include <assert.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 
 #include <dice/chains/intercept.h>
+#include <dice/ensure.h>
 #include <dice/events/memaccess.h>
 #include <dice/interpose.h>
 #include <dice/log.h>
@@ -15,13 +15,6 @@
 #include <dice/pubsub.h>
 
 
-
-#define ensure(COND)                                                           \
-    {                                                                          \
-        if (!(COND)) {                                                         \
-            log_fatal("error: %s", #COND);                                     \
-        }                                                                      \
-    }
 
 typedef void (*test_f)(void);
 

--- a/test/tsan/tsan_test.c.in
+++ b/test/tsan/tsan_test.c.in
@@ -2,12 +2,12 @@
  * Copyright (C) Huawei Technologies Co., Ltd. 2025. All rights reserved.
  * SPDX-License-Identifier: 0BSD
  */
-#include <assert.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 
 #include <dice/chains/intercept.h>
+#include <dice/ensure.h>
 #include <dice/events/memaccess.h>
 #include <dice/interpose.h>
 #include <dice/log.h>
@@ -36,13 +36,6 @@ _tmpl_map(UPCASE, _tmpl_upcase);
 _tmpl_map(EV_TYPE, EVENT_MA_UPCASE);
 _tmpl_map(PARAM_strong, 0);
 _tmpl_map(PARAM_weak, 1);
-
-#define ensure(COND)                                                           \
-    {                                                                          \
-        if (!(COND)) {                                                         \
-            log_fatal("error: %s", #COND);                                     \
-        }                                                                      \
-    }
 
 typedef void (*test_f)(void);
 


### PR DESCRIPTION
When building the tests in Release mode, in some systems NDEBUG is defined.  This commit replaces assert() in all tests with the already defined ensure() macro, which does the same thing, but does not go away with NDEBUG.