### PR TITLE
fix: Memcpy interceptor and related tests

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -30,10 +30,6 @@ jobs:
              -DCMAKE_CXX_COMPILER=${{ matrix.cfg.cxx }}
              -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
 
-      - name: Enable memcpy interposition?
-        if: ${{ matrix.cfg.cc == 'gcc' }}
-        run: cmake -S. -Bbuild -DDICE_INTERPOSE_MEMCPY=on
-
       - name: Build
         run: cmake --build build
       - name: Test

--- a/src/mod/CMakeLists.txt
+++ b/src/mod/CMakeLists.txt
@@ -15,7 +15,7 @@ foreach(SRC ${SRCS})
   get_filename_component(MODULE ${SRC} NAME_WLE)
   set(TARGET dice-${MODULE})
 
-  if(${TARGET} STREQUAL "dice-memcpy" AND NOT ${DICE_INTERPOSE_MEMCPY})
+  if(${TARGET} STREQUAL "dice-memcpy")
     continue()
   endif()
 

--- a/test/interpose/CMakeLists.txt
+++ b/test/interpose/CMakeLists.txt
@@ -53,10 +53,6 @@ set(MODS
     sem
     cxa)
 
-if(${DICE_INTERPOSE_MEMCPY})
-  set(MODS memcpy ${MODS})
-endif()
-
 if(NOT ${ENABLE_SANITIZER})
   # malloc does not play well with the sanitizers
   set(MODS malloc ${MODS})
@@ -93,3 +89,8 @@ foreach(MOD ${MODS})
     target_link_libraries(${TARGET} PRIVATE ${LIBSAN_LINK})
   endif()
 endforeach()
+
+# Add the test executable for memcpy
+add_executable(memcpy_test ${CMAKE_CURRENT_SOURCE_DIR}/memcpy_test.c)
+target_link_libraries(memcpy_test PRIVATE dice.o tsano pthread)
+add_test(NAME memcpy_test COMMAND memcpy_test)

--- a/test/interpose/memcpy_test.c
+++ b/test/interpose/memcpy_test.c
@@ -163,59 +163,59 @@ PS_SUBSCRIBE(INTERCEPT_AFTER, EVENT_MEMSET, {
 })
 
 
-static void
-event_init(void *ptr, size_t n)
-{
-    char *buf = ptr;
-    for (size_t i = 0; i < n; i++)
-        buf[i] = rand() % 256;
-}
-
 /* test case */
-
+const int SIZE = 10;
 static void
 test_memcpy(void)
 {
-    /* initialize event with random content */
-    event_init(&E_memcpy, sizeof(struct memcpy_event));
-    /* call memcpy with arguments */
     enable(fake_memcpy);
-     void *  ret =                                   //
+    char dest[SIZE];
+    E_memcpy.dest = dest;
+    char hello[] = "Hello!";
+    E_memcpy.src= hello;
+    E_memcpy.num = strlen(E_memcpy.src) + 1;
+    E_memcpy.ret = E_memcpy.dest;
+    void *  ret =                                   //
                                  memcpy(                                    //
                                      E_memcpy.dest,                           //
                                      E_memcpy.src,                           //
-                                     E_memcpy.num                                  );
- ensure(ret == E_memcpy.ret);
+                                     E_memcpy.num                                  );                             
+    ensure(ret == E_memcpy.dest);
     disable();
 }
 static void
 test_memmove(void)
 {
-    /* initialize event with random content */
-    event_init(&E_memmove, sizeof(struct memmove_event));
-    /* call memmove with arguments */
     enable(fake_memmove);
-     void *  ret =                                   //
+    char dest[SIZE];
+    E_memmove.dest = dest;
+    char hello[] = "Hi there!";
+    E_memmove.src= hello;
+    E_memmove.count = 2;
+    E_memmove.ret = E_memmove.dest;
+    void *  ret =                                   //
                                  memmove(                                    //
                                      E_memmove.dest,                           //
                                      E_memmove.src,                           //
                                      E_memmove.count                                  );
- ensure(ret == E_memmove.ret);
+    ensure(ret == E_memmove.dest);
     disable();
 }
 static void
 test_memset(void)
 {
-    /* initialize event with random content */
-    event_init(&E_memset, sizeof(struct memset_event));
-    /* call memset with arguments */
     enable(fake_memset);
-     void *  ret =                                   //
+    char dest[SIZE];
+    E_memset.ptr = dest;
+    E_memset.value= 3;
+    E_memset.num = 5;
+    E_memset.ret = E_memset.ptr;
+    void *  ret =                                   //
                                  memset(                                    //
                                      E_memset.ptr,                           //
                                      E_memset.value,                           //
                                      E_memset.num                                  );
- ensure(ret == E_memset.ret);
+    ensure(ret == E_memset.ptr);
     disable();
 }
 


### PR DESCRIPTION
Made a few changes to add the tests from memcpy_test into the main pipeline:

- for alpine to pass, I've added the memcpy dependencies separately in test/interpose/CMakeLists.txt
- clang overwrites the results from the fake function calls. Basically, ret = memcpy(...) captures the value of the destination argument, rather than E_memcpy.ret which was returned by the fake_memcpy function. As a result, the assertions following the fake function calls were adjusted accordingly
- added the memory handling tests as default tests, therefore I removed the flag DICE_INTERPOSE_MEMCPY