### PR TITLE
Add -fPIC compilation flag for mods

### DIFF
--- a/src/mod/CMakeLists.txt
+++ b/src/mod/CMakeLists.txt
@@ -34,7 +34,7 @@ foreach(SRC ${SRCS})
 
   add_library(${TARGET} SHARED ${SRC})
   target_link_libraries(${TARGET} PRIVATE dice dice.h)
-  target_compile_options(${TARGET} PRIVATE ${OPTIONS_${MODULE}})
+  target_compile_options(${TARGET} PRIVATE -fPIC ${OPTIONS_${MODULE}})
   set_target_properties(${TARGET} PROPERTIES PREFIX "")
   if(APPLE)
     # Allow unresolved symbols that will be provided by the sanitizer/runtime at

--- a/src/mod/self.c
+++ b/src/mod/self.c
@@ -39,7 +39,6 @@
 #endif
 #include <dice/chains/intercept.h>
 #include <dice/events/pthread.h>
-#include <dice/log.h>
 #include <dice/mempool.h>
 #include <dice/module.h>
 #include <dice/pubsub.h>


### PR DESCRIPTION
Make the use of -fPIC more consistent across compilation units to avoid issues when creating shared libraries