### PR TITLE
deps: Update tmplr dependency

### DIFF
--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -3,8 +3,31 @@
 
 add_subdirectory(tsano)
 
+set(TMPLR_SRCDIR ${CMAKE_CURRENT_SOURCE_DIR}/tmplr)
+set(TMPLR_BINDIR ${CMAKE_CURRENT_BINARY_DIR}/tmplr)
+set(TMPLR_VERSION_H ${TMPLR_BINDIR}/version.h)
+
+file(MAKE_DIRECTORY ${TMPLR_BINDIR})
+
+add_custom_command(
+  OUTPUT ${TMPLR_VERSION_H}
+  COMMAND /bin/sh -c
+          "${TMPLR_SRCDIR}/.versionize.sh -r ${TMPLR_SRCDIR}/version.h.in > ${TMPLR_VERSION_H}"
+  DEPENDS ${TMPLR_SRCDIR}/.versionize.sh ${TMPLR_SRCDIR}/version.h.in
+  WORKING_DIRECTORY ${TMPLR_SRCDIR}
+  VERBATIM)
+
+function(dice_configure_tmplr_target)
+  target_include_directories(tmplr PRIVATE ${TMPLR_SRCDIR}/include
+                                            ${TMPLR_BINDIR})
+  set_target_properties(
+    tmplr
+    PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bin)
+endfunction()
+
 if(NOT CMAKE_TOOLCHAIN_FILE)
-  add_subdirectory(tmplr)
+  add_executable(tmplr ${TMPLR_SRCDIR}/tmplr.c ${TMPLR_VERSION_H})
+  dice_configure_tmplr_target()
 else()
   # If we are cross-compiling Dice, we still have to ensure tmplr is built with
   # the host compiler since it is used to generate some of Dice's source files.
@@ -14,16 +37,16 @@ else()
   # then overwrite it with a host-compiled one.
 
   # Step 1. build tmplr with cross toolchain
-  add_executable(tmplr tmplr/tmplr.c)
+  add_executable(tmplr ${TMPLR_SRCDIR}/tmplr.c ${TMPLR_VERSION_H})
+  dice_configure_tmplr_target()
 
   # Step 2. prepare tmplr with host default compiler as external project
-  set(TMPLR_SRCDIR ${CMAKE_CURRENT_SOURCE_DIR}/tmplr)
-  set(TMPLR_BINDIR ${CMAKE_CURRENT_BINARY_DIR}/tmplr-host)
+  set(TMPLR_HOST_BINDIR ${CMAKE_CURRENT_BINARY_DIR}/tmplr-host)
   include(ExternalProject)
   ExternalProject_Add(
     tmplr-host
     SOURCE_DIR ${TMPLR_SRCDIR}
-    BINARY_DIR ${TMPLR_BINDIR}
+    BINARY_DIR ${TMPLR_HOST_BINDIR}
     CMAKE_ARGS -DCMAKE_BUILD_TYPE=Release
     INSTALL_COMMAND true)
 
@@ -34,5 +57,6 @@ else()
   add_custom_command(
     TARGET tmplr
     POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy ${TMPLR_BINDIR}/tmplr $<TARGET_FILE:tmplr>)
+    COMMAND ${CMAKE_COMMAND} -E copy ${TMPLR_HOST_BINDIR}/tmplr
+            $<TARGET_FILE:tmplr>)
 endif()

--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -6,14 +6,23 @@ add_subdirectory(tsano)
 set(TMPLR_SRCDIR ${CMAKE_CURRENT_SOURCE_DIR}/tmplr)
 set(TMPLR_BINDIR ${CMAKE_CURRENT_BINARY_DIR}/tmplr)
 set(TMPLR_VERSION_H ${TMPLR_BINDIR}/version.h)
+set(TMPLR_VERSION_IN ${TMPLR_BINDIR}/version.h.in)
+set(TMPLR_VERSIONIZE_CMAKE ${CMAKE_CURRENT_BINARY_DIR}/tmplr-versionize.cmake)
 
 file(MAKE_DIRECTORY ${TMPLR_BINDIR})
+file(WRITE ${TMPLR_VERSION_IN}
+     "#ifndef TMPLR_VERSION_H\n#define TMPLR_VERSION_H\n#define TMPLR_VERSION \"dice-__VERSION__\"\n#endif\n")
+file(WRITE ${TMPLR_VERSIONIZE_CMAKE}
+     "execute_process(\n"
+     "  COMMAND \"${TMPLR_SRCDIR}/.versionize.sh\" -r \"\${INPUT}\"\n"
+     "  OUTPUT_FILE \"\${OUTPUT}\"\n"
+     "  COMMAND_ERROR_IS_FATAL ANY)\n")
 
 add_custom_command(
   OUTPUT ${TMPLR_VERSION_H}
-  COMMAND /bin/sh -c
-          "${TMPLR_SRCDIR}/.versionize.sh -r ${TMPLR_SRCDIR}/version.h.in > ${TMPLR_VERSION_H}"
-  DEPENDS ${TMPLR_SRCDIR}/.versionize.sh ${TMPLR_SRCDIR}/version.h.in
+  COMMAND ${CMAKE_COMMAND} -DINPUT=${TMPLR_VERSION_IN} -DOUTPUT=${TMPLR_VERSION_H}
+          -P ${TMPLR_VERSIONIZE_CMAKE}
+  DEPENDS ${TMPLR_SRCDIR}/.versionize.sh ${TMPLR_VERSION_IN}
   WORKING_DIRECTORY ${TMPLR_SRCDIR}
   VERBATIM)
 
@@ -40,15 +49,26 @@ else()
   add_executable(tmplr ${TMPLR_SRCDIR}/tmplr.c ${TMPLR_VERSION_H})
   dice_configure_tmplr_target()
 
-  # Step 2. prepare tmplr with host default compiler as external project
+  # Step 2. build tmplr with the host compiler in a separate directory.
   set(TMPLR_HOST_BINDIR ${CMAKE_CURRENT_BINARY_DIR}/tmplr-host)
-  include(ExternalProject)
-  ExternalProject_Add(
-    tmplr-host
-    SOURCE_DIR ${TMPLR_SRCDIR}
-    BINARY_DIR ${TMPLR_HOST_BINDIR}
-    CMAKE_ARGS -DCMAKE_BUILD_TYPE=Release
-    INSTALL_COMMAND true)
+  set(TMPLR_HOST_VERSION_H ${TMPLR_HOST_BINDIR}/version.h)
+  set(TMPLR_HOST_VERSION_IN ${TMPLR_HOST_BINDIR}/version.h.in)
+  find_program(TMPLR_HOST_CC NAMES cc clang gcc REQUIRED)
+
+  add_custom_command(
+    OUTPUT ${TMPLR_HOST_BINDIR}/tmplr
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${TMPLR_HOST_BINDIR}
+    COMMAND ${CMAKE_COMMAND} -E copy ${TMPLR_VERSION_IN} ${TMPLR_HOST_VERSION_IN}
+    COMMAND
+      ${CMAKE_COMMAND} -DINPUT=${TMPLR_HOST_VERSION_IN}
+      -DOUTPUT=${TMPLR_HOST_VERSION_H} -P ${TMPLR_VERSIONIZE_CMAKE}
+    COMMAND
+      ${TMPLR_HOST_CC} -std=c99 -O3 -Wall -Wextra -Wpedantic -Wshadow -Werror
+      -I${TMPLR_SRCDIR}/include -I${TMPLR_HOST_BINDIR} -o
+      ${TMPLR_HOST_BINDIR}/tmplr ${TMPLR_SRCDIR}/tmplr.c
+    DEPENDS ${TMPLR_SRCDIR}/tmplr.c ${TMPLR_SRCDIR}/.versionize.sh
+            ${TMPLR_VERSION_IN})
+  add_custom_target(tmplr-host DEPENDS ${TMPLR_HOST_BINDIR}/tmplr)
 
   # Step 3. Create dependency to build tmplr-host version when tmplr is built.
   add_dependencies(tmplr tmplr-host)

--- a/src/dice/CMakeLists.txt
+++ b/src/dice/CMakeLists.txt
@@ -49,6 +49,7 @@ add_custom_command(
   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/dispatch.c.in
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 add_custom_target(expand-dispatch DEPENDS tmplr ${DISPATCH_C})
+set_source_files_properties(${DISPATCH_C} PROPERTIES GENERATED TRUE)
 
 # CHAIN_CONTROL has only events 98..99
 set(EEE_0 98 99)
@@ -73,6 +74,7 @@ foreach(CHAIN ${CHAINS})
     DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/dispatch_chain.c.in
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
   add_custom_target(expand-dispatch_${CHAIN} DEPENDS ${DISPATCH_CHAIN_C})
+  set_source_files_properties(${DISPATCH_CHAIN_C} PROPERTIES GENERATED TRUE)
   add_dependencies(expand-dispatch expand-dispatch_${CHAIN})
 endforeach()
 set(DISPATCH_SRCS ${DISPATCH_SRCS} ${DISPATCH_GENERATED})
@@ -94,6 +96,7 @@ add_compile_definitions(DICE_MULTIFILE_MODULE DICE_MODULE_SLOT=0)
 # installed in the system. Dispatch won't be used for this library except for
 # the internal initialization with chain 0 (CHAIN_CONTROL).
 add_library(dice SHARED ${SRCS})
+add_dependencies(dice expand-dispatch)
 target_link_libraries(dice PUBLIC dice.h pthread)
 install(TARGETS dice DESTINATION lib)
 
@@ -102,6 +105,7 @@ install(TARGETS dice DESTINATION lib)
 # can be linked to other modules. See the dispatcher generation above for
 # details on the chains, events and slots handled by dispatch and callbacks.
 add_library(dice.o OBJECT ${SRCS} ${DISPATCH_SRCS})
+add_dependencies(dice.o expand-dispatch)
 target_link_libraries(dice.o PUBLIC dice.h)
 
 # dice-box.o - OBJECT library that seals pubsub, registry, and mempool
@@ -124,6 +128,7 @@ target_link_libraries(dice-pubsub-box.o PRIVATE dice.h)
 # dice-core.o - OBJECT library as dice.o but without dispatchers. Can be used
 # for perfomance testing or to link with custom dispatchers.
 add_library(dice-core.o OBJECT ${SRCS})
+add_dependencies(dice-core.o expand-dispatch)
 target_link_libraries(dice-core.o PUBLIC dice.h)
 
 # dice-override.o - OBJECT library to override memset (and potentially others)

--- a/src/dice/CMakeLists.txt
+++ b/src/dice/CMakeLists.txt
@@ -44,7 +44,7 @@ message(STATUS "Dispatch slots: ${SSS}")
 set(DISPATCH_C ${CMAKE_CURRENT_BINARY_DIR}/dispatch.c)
 add_custom_command(
   OUTPUT ${DISPATCH_C}
-  COMMAND $<TARGET_FILE:tmplr> "-DCCC=${CCC}" "-DSSS=${SSX}" -s
+  COMMAND $<TARGET_FILE:tmplr> -P_tmpl "-DCCC=${CCC}" "-DSSS=${SSX}" -s
           ${CMAKE_CURRENT_SOURCE_DIR}/dispatch.c.in > dispatch.c
   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/dispatch.c.in
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
@@ -65,10 +65,11 @@ foreach(CHAIN ${CHAINS})
   add_custom_command(
     OUTPUT ${DISPATCH_CHAIN_C}
     COMMAND
-      cat ${CMAKE_CURRENT_SOURCE_DIR}/dispatch_chain.c.in | #
-      $<TARGET_FILE:tmplr> "-DCCC=${CHAIN}" "-DEEE='${eee}'" "-DSSS='${SSS}'" -i
-      | $<TARGET_FILE:tmplr> "-DEEE='${eee}'" "-DSSS='${SSS}'" -P_tmpl2 -i >
-      dispatch_${CHAIN}.c
+      cat ${CMAKE_CURRENT_SOURCE_DIR}/dispatch_chain.c.in #
+      | $<TARGET_FILE:tmplr> -P_tmpl -l 1024 #
+      "-DCCC=${CHAIN}" "-DEEE='${eee}'" "-DSSS='${SSS}'" -i #
+      | $<TARGET_FILE:tmplr> -P_tmpl2 -l 1024 #
+      "-DEEE='${eee}'" "-DSSS='${SSS}'" -i > dispatch_${CHAIN}.c
     DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/dispatch_chain.c.in
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
   add_custom_target(expand-dispatch_${CHAIN} DEPENDS ${DISPATCH_CHAIN_C})

--- a/src/mod/CMakeLists.txt
+++ b/src/mod/CMakeLists.txt
@@ -6,7 +6,7 @@ set(TSAN_C_IN ${CMAKE_CURRENT_SOURCE_DIR}/tsan.c.in)
 
 add_custom_command(
   OUTPUT ${TSAN_C}
-  COMMAND $<TARGET_FILE:tmplr> ${TSAN_C_IN} > tsan.c
+  COMMAND $<TARGET_FILE:tmplr> -P_tmpl ${TSAN_C_IN} > tsan.c
   DEPENDS ${TSAN_C_IN}
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 

--- a/src/mod/CMakeLists.txt
+++ b/src/mod/CMakeLists.txt
@@ -6,12 +6,13 @@ set(TSAN_C_IN ${CMAKE_CURRENT_SOURCE_DIR}/tsan.c.in)
 
 add_custom_command(
   OUTPUT ${TSAN_C}
-  COMMAND $<TARGET_FILE:tmplr> -P_tmpl ${TSAN_C_IN} > tsan.c
-  DEPENDS ${TSAN_C_IN}
+  COMMAND $<TARGET_FILE:tmplr> -P_tmpl ${TSAN_C_IN} > tsan.c.tmp
+  COMMAND ${CMAKE_COMMAND} -E rename tsan.c.tmp tsan.c
+  DEPENDS tmplr ${TSAN_C_IN}
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
 add_custom_target(expand-tsan.c DEPENDS ${TSAN_C})
-add_dependencies(expand-tsan.c tmplr)
+set_source_files_properties(${TSAN_C} PROPERTIES GENERATED TRUE)
 
 set(OVERRIDE_TYPES "" "Debug")
 if("${CMAKE_BUILD_TYPE}" IN_LIST OVERRIDE_TYPES)
@@ -28,8 +29,7 @@ set(OPTIONS_memcpy -fno-builtin-memcpy -fno-builtin-memset
 set(TSAN_SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/tsan.c)
 
 file(GLOB SRCS *.c)
-list(REMOVE_ITEM SRCS ${TSAN_SOURCE})
-list(APPEND SRCS ${TSAN_C})
+list(APPEND SRCS ${TSAN_SOURCE})
 
 if(APPLE)
   list(REMOVE_ITEM SRCS ${CMAKE_CURRENT_SOURCE_DIR}/pthread_spinlock.c)
@@ -38,11 +38,15 @@ endif()
 foreach(SRC ${SRCS})
   get_filename_component(MODULE ${SRC} NAME_WLE)
   set(TARGET dice-${MODULE})
+  set(BUILD_SRC ${SRC})
+  if("${MODULE}" STREQUAL "tsan")
+    set(BUILD_SRC ${TSAN_C})
+  endif()
   if(NOT ${DICE_MEMSET} AND ${TARGET} MATCHES "wrap_memset")
     continue()
   endif()
 
-  add_library(${TARGET} SHARED ${SRC})
+  add_library(${TARGET} SHARED ${BUILD_SRC})
   target_link_libraries(${TARGET} PRIVATE dice dice.h)
   target_compile_options(${TARGET} PRIVATE ${OPTIONS_${MODULE}})
   set_target_properties(${TARGET} PROPERTIES PREFIX "")
@@ -58,7 +62,7 @@ foreach(SRC ${SRCS})
       target_link_libraries(${TARGET} PRIVATE dice-override.o)
     endif()
 
-    add_library(${TARGET}.o OBJECT ${SRC})
+    add_library(${TARGET}.o OBJECT ${BUILD_SRC})
     target_link_libraries(${TARGET}.o PRIVATE dice.h)
     target_compile_options(${TARGET}.o PRIVATE)
     target_compile_options(${TARGET}.o PRIVATE ${OPTIONS_${MODULE}})
@@ -68,9 +72,10 @@ foreach(SRC ${SRCS})
   endif()
 
   foreach(ENDING ${ENDINGS})
-    if("${MODULE}" IN_LIST TSAN_MODULES)
+    if("${MODULE}" STREQUAL "tsan")
       add_dependencies(${TARGET}${ENDING} expand-tsan.c)
-    else()
+    endif()
+    if(NOT "${MODULE}" IN_LIST TSAN_MODULES)
       if(NOT "${DICE_SANITIZER}" STREQUAL "")
         target_compile_options(${TARGET}${ENDING}
                                PUBLIC -fsanitize=${DICE_SANITIZER})

--- a/test/interpose/CMakeLists.txt
+++ b/test/interpose/CMakeLists.txt
@@ -96,16 +96,19 @@ foreach(MOD ${MODS})
       $<TARGET_FILE:tmplr> "-DINCL=${INCL_${MOD}}" "-DFOO=${FUNS_${MOD}}"
       ${CMAKE_CURRENT_SOURCE_DIR}/interposed_.h.in
       ${CMAKE_CURRENT_SOURCE_DIR}/interpose_test.c.in #
-      > ${TARGET}_.c
+      > ${TARGET}_.c.tmp
+    COMMAND ${CMAKE_COMMAND} -E rename ${TARGET}_.c.tmp ${TARGET}_.c
     COMMAND
       $<TARGET_FILE:tmplr> -sP\\$$_ "-DFOO=${FUNS_${MOD}}"
       ${CMAKE_CURRENT_SOURCE_DIR}/interposed__.h.in ${TARGET}_.c #
-      > ${TARGET}.c
+      > ${TARGET}.c.tmp
+    COMMAND ${CMAKE_COMMAND} -E rename ${TARGET}.c.tmp ${TARGET}.c
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/interpose_test.c.in
             ${CMAKE_CURRENT_SOURCE_DIR}/interposed_.h.in
             ${CMAKE_CURRENT_SOURCE_DIR}/interposed__.h.in)
   add_custom_target(expand-test-${MOD} DEPENDS ${TARGET_SRC})
+  set_source_files_properties(${TARGET_SRC} PROPERTIES GENERATED TRUE)
   add_dependencies(expand-tests expand-test-${MOD})
 endforeach()
 
@@ -113,6 +116,7 @@ endforeach()
 foreach(MOD ${MODS})
   set(TARGET ${MOD}_test)
   add_executable(${TARGET} ${CMAKE_CURRENT_BINARY_DIR}/${TARGET}.c)
+  add_dependencies(${TARGET} expand-test-${MOD})
   target_link_libraries(${TARGET} PRIVATE dice.h dice tsano pthread)
   target_compile_options(
     ${TARGET} PRIVATE -fno-builtin-memcpy -fno-builtin-memset

--- a/test/interpose/CMakeLists.txt
+++ b/test/interpose/CMakeLists.txt
@@ -93,7 +93,7 @@ foreach(MOD ${MODS})
   add_custom_command(
     OUTPUT ${TARGET_SRC}
     COMMAND
-      $<TARGET_FILE:tmplr> -P$$ "-DINCL=${INCL_${MOD}}" "-DFOO=${FUNS_${MOD}}"
+      $<TARGET_FILE:tmplr> "-DINCL=${INCL_${MOD}}" "-DFOO=${FUNS_${MOD}}"
       ${CMAKE_CURRENT_SOURCE_DIR}/interposed_.h.in
       ${CMAKE_CURRENT_SOURCE_DIR}/interpose_test.c.in #
       > ${TARGET}_.c

--- a/test/tsan/CMakeLists.txt
+++ b/test/tsan/CMakeLists.txt
@@ -9,8 +9,8 @@ set(TSAN_TEST_C ${CMAKE_CURRENT_BINARY_DIR}/tsan_test.c)
 
 add_custom_command(
   OUTPUT ${TSAN_TEST_C}
-  COMMAND $<TARGET_FILE:tmplr> ${CMAKE_CURRENT_SOURCE_DIR}/tsan_test.c.in >
-          tsan_test.c
+  COMMAND $<TARGET_FILE:tmplr> -P _tmpl ${CMAKE_CURRENT_SOURCE_DIR}/tsan_test.c.in
+          > tsan_test.c
   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/tsan_test.c.in
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 add_custom_target(tsan_test-expand DEPENDS ${TSAN_TEST_C})

--- a/test/tsan/CMakeLists.txt
+++ b/test/tsan/CMakeLists.txt
@@ -10,14 +10,17 @@ set(TSAN_TEST_C ${CMAKE_CURRENT_BINARY_DIR}/tsan_test.c)
 add_custom_command(
   OUTPUT ${TSAN_TEST_C}
   COMMAND $<TARGET_FILE:tmplr> -P _tmpl ${CMAKE_CURRENT_SOURCE_DIR}/tsan_test.c.in
-          > tsan_test.c
+          > tsan_test.c.tmp
+  COMMAND ${CMAKE_COMMAND} -E rename tsan_test.c.tmp tsan_test.c
   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/tsan_test.c.in
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 add_custom_target(tsan_test-expand DEPENDS ${TSAN_TEST_C})
+set_source_files_properties(${TSAN_TEST_C} PROPERTIES GENERATED TRUE)
 add_dependencies(expand-tests tsan_test-expand)
 
 # compile command
 add_executable(tsan_test ${TSAN_TEST_C})
+add_dependencies(tsan_test tsan_test-expand)
 target_link_libraries(tsan_test PRIVATE dice-tsan.o dice-stacktrace.o)
 target_link_libraries(tsan_test PRIVATE dice.h dice pthread)
 


### PR DESCRIPTION
This PR removes tmplr from the deps tree and fetches it normally. For some reason the history in the deps/tmplr cannot be updated by git subtree, and since tmplr gets security fixes and other updates more regularly, it is better to use a simpler method like this to keep track of the dependency.