### PR TITLE
Fixing clang-tidy's insecure snprintf

### DIFF
--- a/include/dice/interpose.h
+++ b/include/dice/interpose.h
@@ -34,7 +34,7 @@
     #error Unsupported platform
 #endif
 
-void *real_sym(const char *, const char *);
+void *real_sym(const char *name, const char *ver);
 
 /* REAL_NAME(F) is the function pointer for the real function F. */
 #define REAL_NAME(F) dice_real_##F##_

--- a/include/dice/log.h
+++ b/include/dice/log.h
@@ -6,9 +6,10 @@
 #define DICE_LOG_H
 
 #include <inttypes.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
+
+#include <dice/utils.h>
 
 #ifdef LOG_UNLOCKED
     #define LOG_LOCK_ACQUIRE
@@ -45,7 +46,7 @@ DICE_WEAK caslock_t log_lock;
 #define log_printf(fmt, ...)                                                   \
     do {                                                                       \
         char msg[LOG_MAX_LEN];                                                 \
-        int n = snprintf(msg, LOG_MAX_LEN, fmt, ##__VA_ARGS__);                \
+        int n = snprintf_s(msg, LOG_MAX_LEN, fmt, ##__VA_ARGS__);                \
         if (write(STDOUT_FILENO, msg, n) == -1) {                              \
             perror("write stdout");                                            \
             exit(EXIT_FAILURE);                                                \

--- a/include/dice/utils.h
+++ b/include/dice/utils.h
@@ -1,0 +1,9 @@
+#ifndef DICE_UTILS_H
+#define DICE_UTILS_H
+
+#include <stdio.h>
+#include <stddef.h>
+
+int snprintf_s(char *s, size_t n, const char *fmt, ...);
+
+#endif /* DICE_UTILS_H */

--- a/src/dice/CMakeLists.txt
+++ b/src/dice/CMakeLists.txt
@@ -68,7 +68,7 @@ set(DISPATCH_SRCS ${DISPATCH_SRCS} ${DISPATCH_GENERATED})
 # ------------------------------------------------------------------------------
 # dice libraries
 # ------------------------------------------------------------------------------
-set(SRCS mempool.c pubsub.c registry.c memset.c ${DISPATCH_C})
+set(SRCS mempool.c pubsub.c registry.c memset.c utils.c ${DISPATCH_C})
 
 # dice (libdice.so) - SHARED library providing interface for plugin modules.
 # Only contains the core components mempool and pubsub. This library gets

--- a/src/dice/utils.c
+++ b/src/dice/utils.c
@@ -1,0 +1,15 @@
+#include <stdarg.h>
+#include <dice/utils.h>
+
+int snprintf_s(char *s, size_t n, const char *fmt, ...)
+{
+    va_list ap;
+    va_start(ap, fmt);
+    int ret = vsnprintf(s, n, fmt, ap);
+    va_end(ap);
+    if (ret < 0 || ret >= (int)n) {
+        if (n > 0) s[0] = '\0'; // Mandatory Annex K behavior on error
+        return -1;
+    }
+    return ret;
+}

--- a/test/log/CMakeLists.txt
+++ b/test/log/CMakeLists.txt
@@ -2,16 +2,16 @@
 # SPDX-License-Identifier: 0BSD                                                #
 
 add_executable(log-fatal-test log_levels.c)
-target_link_libraries(log-fatal-test PRIVATE dice.h)
+target_link_libraries(log-fatal-test PRIVATE dice)
 target_compile_options(log-fatal-test PRIVATE -DLOG_LEVEL=FATAL)
 add_test(NAME log-fatal-test COMMAND log-fatal-test)
 
 add_executable(log-info-test log_levels.c)
-target_link_libraries(log-info-test PRIVATE dice.h)
+target_link_libraries(log-info-test PRIVATE dice)
 target_compile_options(log-info-test PRIVATE -DLOG_LEVEL=INFO)
 add_test(NAME log-info-test COMMAND log-info-test)
 
 add_executable(log-debug-test log_levels.c)
-target_link_libraries(log-debug-test PRIVATE dice.h)
+target_link_libraries(log-debug-test PRIVATE dice)
 target_compile_options(log-debug-test PRIVATE -DLOG_LEVEL=DEBUG)
 add_test(NAME log-debug-test COMMAND log-debug-test)

--- a/test/order/CMakeLists.txt
+++ b/test/order/CMakeLists.txt
@@ -35,7 +35,7 @@ add_library(publisher SHARED)
 target_link_libraries(publisher PRIVATE publisher.o dice)
 
 add_executable(order_test order_test.c)
-target_link_libraries(order_test PRIVATE dice.h mock_publisher)
+target_link_libraries(order_test PRIVATE dice mock_publisher)
 
 set(DICESO ${CMAKE_CURRENT_BINARY_DIR}/../../src/dice/libdice.${SO})
 

--- a/test/traces/CMakeLists.txt
+++ b/test/traces/CMakeLists.txt
@@ -19,7 +19,7 @@ foreach(SRC ${SRCS})
     target_compile_options(${TARGET} PRIVATE -std=c++11)
   endif()
 
-  target_link_libraries(${TARGET} PRIVATE mock_checker tsano pthread)
+  target_link_libraries(${TARGET} PRIVATE mock_checker tsano pthread dice)
 
   add_test(
     NAME ${TARGET}-test


### PR DESCRIPTION
This fix is for clang-tidy for the clang-analyzer-security.insecureAPI.* check, since snprintf was flagged as insecure by the c11 standards.