### PR TITLE
feat: explicit plugin module list

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,6 +119,11 @@ if(NOT "${DICE_MAIN_HOOKS}")
   add_compile_definitions(DICE_MAIN_START_DISABLE)
 endif()
 
+option(DICE_PUBSUB_CTOR_INIT "Ensure pubsub is eventually initd via constructor" on)
+if(NOT "${DICE_PUBSUB_CTOR_INIT}")
+  add_compile_definitions(DICE_DISABLE_PUBUSB_CTOR_INIT)
+endif()
+
 # ------------------------------------------------------------------------------
 # Include directories
 # ------------------------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,7 +121,7 @@ endif()
 
 option(DICE_PUBSUB_CTOR_INIT "Ensure pubsub is eventually initd via constructor" on)
 if(NOT "${DICE_PUBSUB_CTOR_INIT}")
-  add_compile_definitions(DICE_DISABLE_PUBUSB_CTOR_INIT)
+  add_compile_definitions(DICE_DISABLE_PUBSUB_CTOR_INIT)
 endif()
 
 # ------------------------------------------------------------------------------

--- a/include/dice/events/dice.h
+++ b/include/dice/events/dice.h
@@ -1,7 +1,7 @@
-#ifndef dice_h_INCLUDED
-#define dice_h_INCLUDED
+#ifndef DICE_EVENTS_DICE_H
+#define DICE_EVENTS_DICE_H
 
-#define EVENT_DICE_INIT  99
-#define EVENT_DICE_READY 98
+#define EVENT_DICE_INIT 99
+#define EVENT_DICE_NOP  98
 
-#endif // dice_h_INCLUDED
+#endif // DICE_EVENTS_DICE_H

--- a/include/dice/events/pthread.h
+++ b/include/dice/events/pthread.h
@@ -58,8 +58,11 @@
 #define EVENT_PTHREAD_SPIN_TRYLOCK       EVENT_SPIN_TRYLOCK
 #define EVENT_PTHREAD_SPIN_UNLOCK        EVENT_SPIN_UNLOCK
 
-#if !defined(__APPLE__) && !defined(__NetBSD__) && !(defined(__linux__) && !defined(__GLIBC__)) || defined(__OHOS__)
-    // pthread_cond_clockwait and pthread_mutex_clocklock are not available in macos, netbsd and alpine
+#if !defined(__APPLE__) && !defined(__NetBSD__) &&                             \
+        !(defined(__linux__) && !defined(__GLIBC__)) ||                        \
+    defined(__OHOS__)
+    // pthread_cond_clockwait and pthread_mutex_clocklock are not available in
+    // macos, netbsd and alpine
     #define HAVE_PTHREAD_CLOCKWAIT_LOCK
 #endif
 
@@ -218,26 +221,26 @@ struct pthread_rwlock_unlock_event {
 };
 
 #if !defined(__APPLE__)
-    struct pthread_spin_lock_event {
-        const void *pc;
-        pthread_spinlock_t *lock;
-        int ret;
-        int (*func)(pthread_spinlock_t *);
-    };
+struct pthread_spin_lock_event {
+    const void *pc;
+    pthread_spinlock_t *lock;
+    int ret;
+    int (*func)(pthread_spinlock_t *);
+};
 
-    struct pthread_spin_trylock_event {
-        const void *pc;
-        pthread_spinlock_t *lock;
-        int ret;
-        int (*func)(pthread_spinlock_t *);
-    };
+struct pthread_spin_trylock_event {
+    const void *pc;
+    pthread_spinlock_t *lock;
+    int ret;
+    int (*func)(pthread_spinlock_t *);
+};
 
-    struct pthread_spin_unlock_event {
-        const void *pc;
-        pthread_spinlock_t *lock;
-        int ret;
-        int (*func)(pthread_spinlock_t *);
-    };
+struct pthread_spin_unlock_event {
+    const void *pc;
+    pthread_spinlock_t *lock;
+    int ret;
+    int (*func)(pthread_spinlock_t *);
+};
 #endif
 
 #endif /* DICE_PTHREAD_H */

--- a/include/dice/mempool.h
+++ b/include/dice/mempool.h
@@ -34,9 +34,11 @@ void *mempool_realloc(void *ptr, size_t size);
  */
 void mempool_free(void *ptr);
 
-/* mempool_aligned_alloc allocates a region of memory of `size` bytes aligned by alignment, which must be a power of 2.
+/* mempool_aligned_alloc allocates a region of memory of `size` bytes aligned by
+ * alignment, which must be a power of 2.
  *
- * Returns a pointer to the allocated memory which is multiple of alignment or NULL if out of memory.
+ * Returns a pointer to the allocated memory which is multiple of alignment or
+ * NULL if out of memory.
  *
  */
 void *mempool_aligned_alloc(size_t alignment, size_t size);

--- a/include/dice/module.h
+++ b/include/dice/module.h
@@ -21,7 +21,8 @@
 #include <dice/log.h>
 #include <dice/pubsub.h>
 
-/* LAST_DISPATCH_SLOT marks the inclusive end of the generated dispatch range. */
+/* LAST_DISPATCH_SLOT marks the inclusive end of the generated dispatch range.
+ */
 #ifndef LAST_DISPATCH_SLOT
     #define LAST_DISPATCH_SLOT 5
 #endif

--- a/src/dice/loader.c
+++ b/src/dice/loader.c
@@ -24,7 +24,7 @@
 int ps_dispatch_max(void);
 void ps_init_();
 
-#ifndef DICE_DISABLE_PUBUSB_CTOR_INIT
+#ifndef DICE_DISABLE_PUBSUB_CTOR_INIT
 /* Force pubsub init in a constructor without priority, ensuring this
  * constructor is last */
 static void __attribute__((constructor))

--- a/src/dice/loader.c
+++ b/src/dice/loader.c
@@ -18,7 +18,8 @@
 #else
     #define PRELOAD "LD_PRELOAD"
 #endif
-#define DICE_DSO "DICE_DSO"
+#define DICE_DSO            "DICE_DSO"
+#define DICE_PLUGIN_MODULES "DICE_PLUGIN_MODULES"
 
 int ps_dispatch_max(void);
 void ps_init_();
@@ -57,10 +58,12 @@ strdup_(const char *str)
 
 PS_SUBSCRIBE(CHAIN_CONTROL, EVENT_DICE_INIT, {
     log_debug("[%4d] INIT: %s ...", DICE_MODULE_SLOT, __FILE__);
-    const char *envvar = getenv(PRELOAD);
+    const char *envvar = getenv(DICE_PLUGIN_MODULES);
+    if (envvar == NULL || envvar[0] == '\0')
+        envvar = getenv(PRELOAD);
     log_debug("[%4d] LOAD: builtin modules: 0..%d", DICE_MODULE_SLOT,
               ps_dispatch_max());
-    if (envvar != NULL) {
+    if (envvar != NULL && envvar[0] != '\0') {
         char *plugins = strdup_(envvar);
         if (plugins == NULL)
             log_fatal("could not duplicate string: %s", envvar);

--- a/src/dice/loader.c
+++ b/src/dice/loader.c
@@ -24,12 +24,15 @@
 int ps_dispatch_max(void);
 void ps_init_();
 
+#ifndef DICE_DISABLE_PUBUSB_CTOR_INIT
 /* Force pubsub init in a constructor without priority, ensuring this
  * constructor is last */
-static void __attribute__((constructor)) init_()
+static void __attribute__((constructor))
+init_()
 {
     ps_init_();
 }
+#endif
 
 #ifndef DICE_DISABLE_LOADER
 static void
@@ -58,8 +61,9 @@ strdup_(const char *str)
 
 PS_SUBSCRIBE(CHAIN_CONTROL, EVENT_DICE_INIT, {
     log_debug("[%4d] INIT: %s ...", DICE_MODULE_SLOT, __FILE__);
-    const char *envvar = getenv(DICE_PLUGIN_MODULES);
-    if (envvar == NULL || envvar[0] == '\0')
+    const char *envvar     = getenv(DICE_PLUGIN_MODULES);
+    const int from_preload = (envvar == NULL || envvar[0] == '\0');
+    if (from_preload)
         envvar = getenv(PRELOAD);
     log_debug("[%4d] LOAD: builtin modules: 0..%d", DICE_MODULE_SLOT,
               ps_dispatch_max());
@@ -80,8 +84,8 @@ PS_SUBSCRIBE(CHAIN_CONTROL, EVENT_DICE_INIT, {
         // case, we can use the envvar DICE_DSO to identify the exact name
         // passed to the PRELOAD.
         envvar = getenv(DICE_DSO);
-        if (envvar == NULL)
-            // skip first library
+        if (envvar == NULL && from_preload)
+            // skip first library only for PRELOAD-based lists
             path = strtok(NULL, ":");
 
         while (path != NULL) {

--- a/src/dice/pubsub.c
+++ b/src/dice/pubsub.c
@@ -65,7 +65,6 @@ ps_initd_(void)
             assert(ps_dispatch_max() >= 0);
             PS_PUBLISH(CHAIN_CONTROL, EVENT_DICE_INIT, 0, 0);
             ready_ = true;
-            PS_PUBLISH(CHAIN_CONTROL, EVENT_DICE_READY, 0, 0);
             return true;
         case START:
             state_ = BLOCK;
@@ -86,7 +85,7 @@ ps_init_(void)
 }
 
 /* Advertise event type names for debugging messages */
-PS_ADVERTISE_TYPE(EVENT_DICE_READY)
+PS_ADVERTISE_TYPE(EVENT_DICE_NOP)
 PS_ADVERTISE_TYPE(EVENT_DICE_INIT)
 PS_DISPATCH_SLOT_ON(DICE_MODULE_SLOT)
 

--- a/src/mod/self.c
+++ b/src/mod/self.c
@@ -661,8 +661,9 @@ DICE_MODULE_FINI({
         if (tid == MAIN_THREAD) {
             log_debug("waiting for %" PRIu64 " threads to die", (born - dead));
 
-            struct self_wait_event ev = { .wait = false };
-            PS_PUBLISH(CAPTURE_EVENT, EVENT_SELF_WAIT, &ev, self ? &self->md : NULL);
+            struct self_wait_event ev = {.wait = false};
+            PS_PUBLISH(CAPTURE_EVENT, EVENT_SELF_WAIT, &ev,
+                       self ? &self->md : NULL);
             if (!ev.wait)
                 break;
         }

--- a/test/ensure_self_fini.c
+++ b/test/ensure_self_fini.c
@@ -16,7 +16,7 @@ vatomic32_t run_called;
 PS_SUBSCRIBE(CAPTURE_EVENT, EVENT_SELF_WAIT, {
     /* wait for all threads to exit */
     struct self_wait_event *ev = EVENT_PAYLOAD(ev);
-    ev->wait = true;
+    ev->wait                   = true;
 })
 
 PS_SUBSCRIBE(CAPTURE_EVENT, EVENT_SELF_FINI, {

--- a/test/ensure_self_fini_detach.c
+++ b/test/ensure_self_fini_detach.c
@@ -16,7 +16,7 @@ vatomic32_t run_called;
 PS_SUBSCRIBE(CAPTURE_EVENT, EVENT_SELF_WAIT, {
     /* wait for all threads to exit */
     struct self_wait_event *ev = EVENT_PAYLOAD(ev);
-    ev->wait = true;
+    ev->wait                   = true;
 })
 
 PS_SUBSCRIBE(CAPTURE_EVENT, EVENT_SELF_FINI, {

--- a/test/intercept_event.c
+++ b/test/intercept_event.c
@@ -2,11 +2,11 @@
  * Copyright (C) Huawei Technologies Co., Ltd. 2025. All rights reserved.
  * SPDX-License-Identifier: 0BSD
  */
-#include <dice/ensure.h>
 #include <pthread.h>
 #include <unistd.h>
 
 #include <dice/chains/intercept.h>
+#include <dice/ensure.h>
 #include <dice/events/memaccess.h>
 #include <dice/log.h>
 #include <dice/module.h>

--- a/test/malloc_free_test.c
+++ b/test/malloc_free_test.c
@@ -2,10 +2,10 @@
  * Copyright (C) Huawei Technologies Co., Ltd. 2025. All rights reserved.
  * SPDX-License-Identifier: 0BSD
  */
-#include <dice/ensure.h>
 #include <pthread.h>
 #include <stdlib.h>
 
+#include <dice/ensure.h>
 #include <vsync/atomic.h>
 
 vatomic32_t count = VATOMIC_INIT(4);

--- a/test/mempool/mempool_align_free_test.c
+++ b/test/mempool/mempool_align_free_test.c
@@ -13,12 +13,14 @@
 #define N_SLABS      9
 #define N_ADDRESSES  (N_SLABS * N_ALIGNMENTS)
 
-void* seen_addresses[N_ADDRESSES] = {};
+void *seen_addresses[N_ADDRESSES] = {};
 
-static void _check_address(void *ptr)
+static void
+_check_address(void *ptr)
 {
     int index = 0;
-    while (index < N_ADDRESSES && (seen_addresses[index] != ptr && seen_addresses[index] != NULL)) {
+    while (index < N_ADDRESSES &&
+           (seen_addresses[index] != ptr && seen_addresses[index] != NULL)) {
         index++;
     }
     ensure(index < N_ADDRESSES);
@@ -31,9 +33,9 @@ main(void)
     srand(time(NULL));
     for (int iteration = 0; iteration < N_ITERATIONS; iteration++) {
         size_t alignment = 1 << (rand() % N_ALIGNMENTS);
-        size_t size = rand() % 1024 * 1024;
-        char data = rand() % (1 << sizeof(char));
-        void *ptr = mempool_aligned_alloc(alignment, size);
+        size_t size      = rand() % 1024 * 1024;
+        char data        = rand() % (1 << sizeof(char));
+        void *ptr        = mempool_aligned_alloc(alignment, size);
 
         if (ptr == NULL) {
             break;

--- a/test/mempool/mempool_alignment_test.c
+++ b/test/mempool/mempool_alignment_test.c
@@ -2,8 +2,8 @@
  * Copyright (C) 2025 Huawei Technologies Co., Ltd.
  * SPDX-License-Identifier: 0BSD
  */
-#include <stdint.h>
 #include <stddef.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <time.h>
 
@@ -16,8 +16,8 @@ main(void)
     srand(time(NULL));
     while (1) {
         size_t alignment = 1 << (rand() % 20);
-        size_t size = rand() % 1024 * 1024;
-        void *ptr = mempool_aligned_alloc(alignment, size);
+        size_t size      = rand() % 1024 * 1024;
+        void *ptr        = mempool_aligned_alloc(alignment, size);
 
         if (ptr == NULL) {
             break;

--- a/test/self/self_wait_test.c
+++ b/test/self/self_wait_test.c
@@ -2,8 +2,8 @@
 
 #include <dice/chains/capture.h>
 #include <dice/chains/intercept.h>
-#include <dice/events/self.h>
 #include <dice/ensure.h>
+#include <dice/events/self.h>
 #include <dice/module.h>
 
 #define NTHREADS 20

--- a/test/simple.c
+++ b/test/simple.c
@@ -2,11 +2,11 @@
  * Copyright (C) Huawei Technologies Co., Ltd. 2025. All rights reserved.
  * SPDX-License-Identifier: 0BSD
  */
-#include <dice/ensure.h>
 #include <pthread.h>
 #include <stdio.h>
 
 #include <dice/chains/intercept.h>
+#include <dice/ensure.h>
 #include <dice/events/memaccess.h>
 #include <dice/pubsub.h>
 #include <vsync/atomic.h>

--- a/test/thread_sequence.c
+++ b/test/thread_sequence.c
@@ -1,4 +1,5 @@
 #include <pthread.h>
+
 #include <vsync/atomic.h>
 
 #define NTHREADS 16


### PR DESCRIPTION
Depends on #247. This PR introduces `DICE_PLUGIN_MODULES` as specific variable to control the modules forcibly loaded by Dice core. If `DICE_PLUGIN_MODULES` is not set, the behavior falls back to the previous behavior, where all libraries in `LD_PRELOAD` are forcibly loaded. This PR also adds a few documentation items that were lacking or became obsolete in the last weeks.