### PR TITLE
ci: bump actions/checkout to v6

### DIFF
--- a/.github/workflows/actions-benchmark.yml
+++ b/.github/workflows/actions-benchmark.yml
@@ -24,11 +24,11 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Checkout Wiki
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{github.repository}}.wiki
           path: ${{github.repository}}.wiki

--- a/.github/workflows/actions-ohos.yml
+++ b/.github/workflows/actions-ohos.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           version: "6.0"
           fixup-path: true
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Configure

--- a/.github/workflows/actions-smolbsd.yml
+++ b/.github/workflows/actions-smolbsd.yml
@@ -20,7 +20,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -20,7 +20,7 @@ jobs:
           cxx: clang++
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Configure
@@ -49,7 +49,7 @@ jobs:
           cxx: clang++
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Configure
@@ -72,7 +72,7 @@ jobs:
         sanitizer: [thread, address, undefined]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Configure
@@ -90,7 +90,7 @@ jobs:
     runs-on: ubuntu-latest
     container: ghcr.io/open-s4c/dice/alpine-ci:latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Configure
@@ -109,7 +109,7 @@ jobs:
     if: true
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Configure

--- a/.github/workflows/docker-smolbsd.yml
+++ b/.github/workflows/docker-smolbsd.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Update Ubuntu dependencies
@@ -54,7 +54,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Log in to the Container registry

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - name: Get compiler version
         run: ${{ matrix.cc }} --version
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Ensure main was fetched


### PR DESCRIPTION
## Summary
- bump active GitHub workflows from `actions/checkout@v4` to `actions/checkout@v6`
- align checkout with GitHub's Node 24 runtime change
- leave `deps/tsano` untouched and preserve existing checkout settings