### PR TITLE
feat: add self_guard_get public interface

### DIFF
--- a/include/dice/self.h
+++ b/include/dice/self.h
@@ -16,10 +16,20 @@
 #include <dice/events/self.h>
 #include <dice/pubsub.h>
 
+enum self_guard {
+    SELF_GUARD_NONE = 0,
+    SELF_GUARD_BETWEEN,
+    SELF_GUARD_SERVING,
+};
+
 /* Returns the Dice-assigned thread identifier for the current handler
  * invocation. IDs start at 1; `NO_THREAD` is reserved for representing no
  * thread and should never be returned. */
 thread_id self_id(struct metadata *self);
+
+/* Returns whether Dice is currently idle, serving a handler, or between a
+ * matching INTERCEPT_BEFORE/INTERCEPT_AFTER pair for the current thread. */
+enum self_guard self_guard_get(struct metadata *self);
 
 /* True when the backing TLS object has been retired (for example, after a
  * thread exit). */

--- a/src/mod/self-box.c
+++ b/src/mod/self-box.c
@@ -13,6 +13,13 @@ self_id(struct metadata *md)
     return self_id_(md);
 }
 
+enum self_guard self_guard_get_(struct metadata *md);
+DICE_HIDE enum self_guard
+self_guard_get(struct metadata *md)
+{
+    return self_guard_get_(md);
+}
+
 bool self_retired_(struct metadata *md);
 DICE_HIDE bool
 self_retired(struct metadata *md)

--- a/src/mod/self.c
+++ b/src/mod/self.c
@@ -61,6 +61,8 @@ struct self {
         size_t size;
         size_t cap;
     } tls;
+    /* Bit 0 marks a BEFORE/AFTER pair in flight. Publication and recursion
+     * suppression bump the counter in steps of 2. */
     int guard;
     bool retired;
 };
@@ -156,6 +158,18 @@ self_id_(struct metadata *md)
     return likely(self) ? self->id : NO_THREAD;
 }
 
+DICE_HIDE enum self_guard
+self_guard_get_(struct metadata *md)
+{
+    struct self *self = (struct self *)md;
+
+    if (unlikely(self == NULL || self->guard <= 0))
+        return SELF_GUARD_NONE;
+    if (self->guard == 1)
+        return SELF_GUARD_BETWEEN;
+    return SELF_GUARD_SERVING;
+}
+
 DICE_HIDE bool
 self_retired_(struct metadata *md)
 {
@@ -232,6 +246,12 @@ DICE_WEAK thread_id
 self_id(struct metadata *md)
 {
     return self_id_(md);
+}
+
+DICE_WEAK enum self_guard
+self_guard_get(struct metadata *md)
+{
+    return self_guard_get_(md);
 }
 
 DICE_WEAK bool
@@ -457,18 +477,20 @@ retire_self_(struct self *self)
 //  pubsub handler
 // -----------------------------------------------------------------------------
 
-#define self_guard(chain, type, event, self)                                   \
-    do {                                                                       \
-        self->guard++;                                                         \
-        log_debug(">> [%" PRIu64 ":0x%" PRIx64 ":%" PRIu64 "] %s/%s: %d",      \
-                  self_id(&self->md), (uint64_t)self->ptid, self->osid,        \
-                  ps_chain_str(chain), ps_type_str(type), self->guard);        \
-        PS_PUBLISH(chain, type, event, &self->md);                             \
-        log_debug("<< [%" PRIu64 ":0x%" PRIx64 ":%" PRIu64 "] %s/%s: %d",      \
-                  self_id(&self->md), (uint64_t)self->ptid, self->osid,        \
-                  ps_chain_str(chain), ps_type_str(type), self->guard);        \
-        self->guard--;                                                         \
-    } while (0)
+static void
+self_publish_(const chain_id chain, const type_id type, void *event,
+              struct self *self)
+{
+    self->guard += 2;
+    log_debug(">> [%" PRIu64 ":0x%" PRIx64 ":%" PRIu64 "] %s/%s: %d",
+              self_id(&self->md), (uint64_t)self->ptid, self->osid,
+              ps_chain_str(chain), ps_type_str(type), self->guard);
+    PS_PUBLISH(chain, type, event, &self->md);
+    log_debug("<< [%" PRIu64 ":0x%" PRIx64 ":%" PRIu64 "] %s/%s: %d",
+              self_id(&self->md), (uint64_t)self->ptid, self->osid,
+              ps_chain_str(chain), ps_type_str(type), self->guard);
+    self->guard -= 2;
+}
 
 static enum ps_err
 self_handle_before_(const chain_id chain, const type_id type, void *event,
@@ -478,7 +500,7 @@ self_handle_before_(const chain_id chain, const type_id type, void *event,
     assert(self);
 
     if (likely(self->guard++ == 0))
-        self_guard(CAPTURE_BEFORE, type, event, self);
+        self_publish_(CAPTURE_BEFORE, type, event, self);
     else
         log_debug(">>> [%" PRIu64 ":0x%" PRIx64 ":%" PRIu64 "] %s/%s: %d",
                   self_id(&self->md), (uint64_t)self->ptid, self->osid,
@@ -495,13 +517,14 @@ self_handle_after_(const chain_id chain, const type_id type, void *event,
     (void)chain;
     assert(self);
 
-    if (likely(self->guard-- == 1))
-        self_guard(CAPTURE_AFTER, type, event, self);
+    if (likely(self->guard == 1))
+        self_publish_(CAPTURE_AFTER, type, event, self);
     else
         log_debug("<<< [%" PRIu64 ":0x%" PRIx64 ":%" PRIu64 "] %s/%s: %d",
                   self_id(&self->md), (uint64_t)self->ptid, self->osid,
                   ps_chain_str(chain), ps_type_str(type), self->guard);
 
+    self->guard--;
     assert(self->guard >= 0);
     return PS_STOP_CHAIN;
 }
@@ -514,7 +537,7 @@ self_handle_event_(const chain_id chain, const type_id type, void *event,
     assert(self);
 
     if (likely(self->guard == 0))
-        self_guard(CAPTURE_EVENT, type, event, self);
+        self_publish_(CAPTURE_EVENT, type, event, self);
     else
         log_debug("!!! [%" PRIu64 ":0x%" PRIx64 ":%" PRIu64 "] %s/%s: %d",
                   self_id(&self->md), (uint64_t)self->ptid, self->osid,
@@ -598,7 +621,7 @@ cleanup_threads_(struct self *own, pthread_t ptid)
     // self object without knowing it is finilizing another thread. To stop the
     // recursion we use the same guard mechanism of normal publications.
     if (own)
-        own->guard++;
+        own->guard += 2;
 
     caslock_acquire(&threads_.lock);
     struct quack_node_s *item = quack_popall(&threads_.retired);
@@ -619,7 +642,7 @@ cleanup_threads_(struct self *own, pthread_t ptid)
     }
     caslock_release(&threads_.lock);
     if (own)
-        own->guard--;
+        own->guard -= 2;
 }
 
 PS_SUBSCRIBE(INTERCEPT_EVENT, EVENT_THREAD_EXIT, {

--- a/test/self/CMakeLists.txt
+++ b/test/self/CMakeLists.txt
@@ -5,6 +5,10 @@ add_executable(self_unique_test self_unique_test.c)
 target_link_libraries(self_unique_test PRIVATE dice-self.o dice dice.h)
 add_test(NAME self-unique-test COMMAND ${DICE_SCRIPT} ./self_unique_test)
 
+add_executable(self_guard_test self_guard_test.c)
+target_link_libraries(self_guard_test PRIVATE dice-self.o dice dice.h)
+add_test(NAME self-guard-test COMMAND ${DICE_SCRIPT} ./self_guard_test)
+
 add_executable(self_wait_test self_wait_test.c)
 target_link_libraries(self_wait_test PRIVATE dice-self.o dice-pthread_create.o dice dice.h)
 add_test(NAME self-wait-test COMMAND ${DICE_SCRIPT} ./self_wait_test)

--- a/test/self/self_guard_test.c
+++ b/test/self/self_guard_test.c
@@ -1,0 +1,46 @@
+#include <dice/chains/capture.h>
+#include <dice/chains/intercept.h>
+#include <dice/ensure.h>
+#include <dice/module.h>
+#include <dice/self.h>
+
+#define EVENT_SELF_GUARD_TEST 100
+
+static vatomic32_t capture_event_seen;
+static vatomic32_t capture_before_seen;
+static vatomic32_t capture_after_seen;
+
+PS_SUBSCRIBE(CAPTURE_EVENT, EVENT_SELF_GUARD_TEST, {
+    ensure(self_guard_get(md) == SELF_GUARD_SERVING);
+    vatomic32_inc(&capture_event_seen);
+})
+
+PS_SUBSCRIBE(CAPTURE_BEFORE, EVENT_SELF_GUARD_TEST, {
+    ensure(self_guard_get(md) == SELF_GUARD_SERVING);
+    vatomic32_inc(&capture_before_seen);
+})
+
+PS_SUBSCRIBE(CAPTURE_AFTER, EVENT_SELF_GUARD_TEST, {
+    ensure(self_guard_get(md) == SELF_GUARD_SERVING);
+    vatomic32_inc(&capture_after_seen);
+})
+
+int
+main(void)
+{
+    ensure(self_guard_get(NULL) == SELF_GUARD_NONE);
+    ensure(self_guard_get(self_md()) == SELF_GUARD_NONE);
+
+    PS_PUBLISH(INTERCEPT_EVENT, EVENT_SELF_GUARD_TEST, NULL, NULL);
+    ensure(vatomic_read(&capture_event_seen) == 1);
+    ensure(self_guard_get(self_md()) == SELF_GUARD_NONE);
+
+    PS_PUBLISH(INTERCEPT_BEFORE, EVENT_SELF_GUARD_TEST, NULL, NULL);
+    ensure(vatomic_read(&capture_before_seen) == 1);
+    ensure(self_guard_get(self_md()) == SELF_GUARD_BETWEEN);
+
+    PS_PUBLISH(INTERCEPT_AFTER, EVENT_SELF_GUARD_TEST, NULL, NULL);
+    ensure(vatomic_read(&capture_after_seen) == 1);
+    ensure(self_guard_get(self_md()) == SELF_GUARD_NONE);
+    return 0;
+}


### PR DESCRIPTION
This interface allows the user to query a metadata object whether the thread is currently serving a publication. It is intended to be when a signal handler triggers. Using `self_md()` the user can get the metadata object (if it exists) and with `self_guard_get(md)` query whether the signal handler was triggered while in Dice code, user code or system code.