### PR TITLE
self: bootstrap main thread statically

### DIFF
--- a/src/mod/self.c
+++ b/src/mod/self.c
@@ -77,6 +77,11 @@ struct tls_item {
 static void cleanup_threads_(struct self *own, pthread_t ptid);
 static struct self *get_self_(void);
 
+#define SELF_TLS_CAP 1024
+
+static struct self main_self_;
+static struct tls_item main_self_tls_[SELF_TLS_CAP];
+
 // -----------------------------------------------------------------------------
 // tls items
 // -----------------------------------------------------------------------------
@@ -84,7 +89,7 @@ static struct self *get_self_(void);
 static void
 tls_init_(struct self *self)
 {
-    self->tls.cap   = 1024;
+    self->tls.cap   = SELF_TLS_CAP;
     self->tls.size  = 0;
     self->tls.items = mempool_alloc(sizeof(struct tls_item) * self->tls.cap);
     if (self->tls.items == NULL)
@@ -381,13 +386,20 @@ static struct self *
 create_self_()
 {
     struct self *self;
-    self          = mempool_alloc(sizeof(struct self));
+
+    if (main_self_.id == NO_THREAD) {
+        self                 = &main_self_;
+        main_self_.tls.items = main_self_tls_;
+        main_self_.tls.cap   = SELF_TLS_CAP;
+    } else {
+        self = mempool_alloc(sizeof(struct self));
+        tls_init_(self);
+    }
     self->guard   = 0;
     self->id      = vatomic64_inc_get(&threads_.count);
     self->ptid    = pthread_self();
     self->osid    = thread_osid_();
     self->retired = false;
-    tls_init_(self);
     return self;
 }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,14 +18,15 @@ set(DICE_intercept_event on)
 
 # Test cases in these lists will be compiled but not ran with sanitizers
 set(IGNORE_address pthread_exit_window ensure_self_fini ensure_self_fini_error
-                   ensure_self_fini_detach)
-set(IGNORE_thread pthread_exit_window)
+                   ensure_self_fini_detach constructor_malloc_test)
+set(IGNORE_thread pthread_exit_window constructor_malloc_test)
 set(IGNORE_undefined)
 
 # Dice script options
 set(DICE_OPTS_thread_sequence -pthread -self -preload $<TARGET_FILE:id_checker>)
 set(DICE_OPTS_simple -self)
 set(DICE_OPTS_intercept_event -self)
+set(DICE_OPTS_constructor_malloc_test -malloc -self)
 set(DICE_OPTS_pthread_create_join -pthread)
 set(DICE_OPTS_pthread_create_exit -pthread)
 set(DICE_OPTS_pthread_create_detach -pthread)
@@ -62,6 +63,10 @@ foreach(SRC ${SRCS})
     endif()
   endif()
 endforeach()
+
+if(TEST constructor_malloc_test)
+  set_tests_properties(constructor_malloc_test PROPERTIES TIMEOUT 5)
+endif()
 
 # Additional configuration of some tests
 target_link_libraries(pthread_exit_window PRIVATE dice-self)

--- a/test/constructor_malloc_test.c
+++ b/test/constructor_malloc_test.c
@@ -1,0 +1,16 @@
+#include <stdlib.h>
+
+static void __attribute__((constructor))
+bootstrap_malloc_(void)
+{
+    void *ptr = malloc(64);
+    if (ptr == NULL)
+        abort();
+    free(ptr);
+}
+
+int
+main(void)
+{
+    return 0;
+}

--- a/test/self/CMakeLists.txt
+++ b/test/self/CMakeLists.txt
@@ -10,6 +10,7 @@ target_link_libraries(self_guard_test PRIVATE dice-self.o dice dice.h)
 add_test(NAME self-guard-test COMMAND ${DICE_SCRIPT} ./self_guard_test)
 
 add_executable(self_wait_test self_wait_test.c)
-target_link_libraries(self_wait_test PRIVATE dice-self.o dice-pthread_create.o dice dice.h)
+target_link_libraries(self_wait_test PRIVATE dice-self.o dice-pthread_create.o
+                                             dice dice.h)
 add_test(NAME self-wait-test COMMAND ${DICE_SCRIPT} ./self_wait_test)
 set_tests_properties(self-wait-test PROPERTIES TIMEOUT 5)


### PR DESCRIPTION
To avoid recursion of malloc on macos, the self object of the main thread is a global (preallocated) object.