### PR TITLE
Upgrade OpenHarmony SDK in OHOS workflow

### DIFF
--- a/.github/workflows/actions-ohos.yml
+++ b/.github/workflows/actions-ohos.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: Setup OpenHarmony SDK
         id: setup_sdk
-        uses: openharmony-rs/setup-ohos-sdk@v0.2.4
+        uses: openharmony-rs/setup-ohos-sdk@v1.0.0
         with:
           version: "6.0"
           fixup-path: true


### PR DESCRIPTION
The OHOS workflow uses another action to obtain the OpenHarmony SDK. This action uses actions that run on node 20 which is deprecated by github from 16th of June 2026. Thjs commit upgrades the OHOS SDK version such that it uses node 24.